### PR TITLE
Update Claude skills with multi-source AllowCombine findings

### DIFF
--- a/claude-skills/SKILL.md
+++ b/claude-skills/SKILL.md
@@ -10,7 +10,6 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 ## Must / Prefer / Avoid
 
 ### MUST DO
-
 - Use `executeOption = "ApplyChangesIfNeeded"` on first refresh of API-created dataflows (default causes `DataflowNeverPublishedError`)
 - Include both a `DataDestinations` annotation AND a companion `_DataDestination` query for Lakehouse output
 - Use `Kind = "Automatic"` (not Manual) when creating new destination tables — Manual causes `DestinationColumnNotFound`
@@ -22,7 +21,6 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 - Use `list_workspaces` and filter by name — there is no `find_workspace` tool
 
 ### PREFER
-
 - Filter early in M queries to enable query folding (push filters to source)
 - Expensive operations (sorting, aggregation) last — streaming operations (filter, select) first
 - Native connectors (SQL Server, Lakehouse) over generic ones (ODBC/OLEDB) for better query folding
@@ -34,7 +32,6 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 - `execute_query` with `customMashupDocument` to iterate on M code before saving
 
 ### AVOID
-
 - `get_authoring_guidance` — deprecated, author M directly
 - Fast Copy with `Table.Group`, `Table.NestedJoin`, or any schema-changing transform
 - Manual column mappings (`ColumnSettings`) for new tables
@@ -45,9 +42,9 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 
 ## Knowledge Files
 
-| File                          | When to Use                                                                      |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| `datafactory-core.md`         | MCP tools, M basics, first-refresh rule, deprecated tools                        |
+| File | When to Use |
+|------|-------------|
+| `datafactory-core.md` | MCP tools, M basics, first-refresh rule, deprecated tools |
 | `datafactory-destinations.md` | Creating/configuring output destinations, DataDestination patterns, AllowCombine |
-| `datafactory-performance.md`  | Query timeouts, chunking, query folding, connector selection                     |
-| `datafactory-advanced.md`     | Fast Copy limits, Action.Sequence, Modern Evaluator                              |
+| `datafactory-performance.md` | Query timeouts, chunking, query folding, connector selection |
+| `datafactory-advanced.md` | Fast Copy limits, Action.Sequence, Modern Evaluator |

--- a/claude-skills/SKILL.md
+++ b/claude-skills/SKILL.md
@@ -12,13 +12,17 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 ### MUST DO
 - Use `executeOption = "ApplyChangesIfNeeded"` on first refresh of API-created dataflows (default causes `DataflowNeverPublishedError`)
 - Include both a `DataDestinations` annotation AND a companion `_DataDestination` query for Lakehouse output
+- Name destination queries `[QueryName]_DataDestination` — e.g., query `Results` gets companion `Results_DataDestination`
 - Use `Kind = "Automatic"` (not Manual) when creating new destination tables — Manual causes `DestinationColumnNotFound`
-- Use `?` null-safe operators in the `_DataDestination` query for new tables (table doesn't exist yet)
+- Always use `IsNewTarget = true` with `?` null-safe operators in API-created dataflows — even when the table exists; `IsNewTarget = false` with direct `[Data]` fails on first refresh
 - Add `[AllowCombine = true]` section attribute when combining multiple source types (Lakehouse + SharePoint, etc.)
+- Use a fresh dataflow for multi-source — never transition a published single-source dataflow to multi-source
+- Consolidate all Lakehouse table reads into a single source query (one `Lakehouse.Contents` call) in multi-source dataflows
 - Re-add connections via `add_connection_to_dataflow` after `save_dataflow_definition` (save may wipe them)
 - Add connections one at a time — array format not supported
 - Validate each connection with `execute_query` after adding
 - Use `list_workspaces` and filter by name — there is no `find_workspace` tool
+- Create a new dataflow instead of reverting a multi-source one to single-source — `save_dataflow_definition` does NOT remove stale connections, and there is no `remove_connection` tool
 
 ### PREFER
 - Filter early in M queries to enable query folding (push filters to source)
@@ -39,6 +43,8 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 - `Action.Sequence` for normal query transformations — only use for side-effecting writes
 - Sorting early in query chains (requires reading all data before returning results)
 - `SELECT *` equivalent without row limits during development — use "Keep First Rows" then remove
+- Reusing a previously-published single-source dataflow for multi-source — stale connections persist and cause instant refresh failure; always create a fresh dataflow for multi-source
+- Separate `Lakehouse.Contents` calls per query in multi-source dataflows — consolidate all Lakehouse table reads into a single query for reliable multi-source refresh
 
 ## Knowledge Files
 

--- a/claude-skills/datafactory-destinations.md
+++ b/claude-skills/datafactory-destinations.md
@@ -176,10 +176,10 @@ shared JoinedOutput = let ... in ...;
 1. create_dataflow              → Create empty dataflow
 2. add_connection_to_dataflow   → Attach ALL source connections (one call per connection)
 3. execute_query                → Discover target lakehouse ID
-4. save_dataflow_definition    → Save complete M document with destination config
+4. save_dataflow_definition     → Save complete M document with destination config
                                    Include [AllowCombine = true] if multi-source
 5. add_connection_to_dataflow   → Re-add connections (save_dataflow_definition may wipe them)
-6. get_dataflow_definition → Verify connections + destination config
+6. get_dataflow_definition      → Verify connections + destination config
 7. refresh_dataflow_background  → Materialize the table
                                    MUST use executeOption="ApplyChangesIfNeeded" on first refresh
 ```
@@ -248,7 +248,7 @@ in
 """
 )
 
-# 4. Re-add connections (validate_and_save may have wiped them)
+# 4. Re-add connections (save_dataflow_definition may have wiped them)
 add_connection_to_dataflow(connectionIds="97b68bdf-...", dataflowId="...", workspaceId="...")
 add_connection_to_dataflow(connectionIds="58699886-...", dataflowId="...", workspaceId="...")
 
@@ -261,7 +261,7 @@ refresh_dataflow_background(dataflowId="...", workspaceId="...", executeOption="
 
 ### Why `ApplyChangesIfNeeded` Is Required (Technical Detail)
 
-API-created dataflows start in an unpublished draft state. Additionally, `save_dataflow_definition` sets `loadEnabled: false` in queryMetadata. The platform reconciles both issues on refresh ONLY when using `ApplyChangesIfNeeded`.
+API-created dataflows start in an unpublished draft state. Additionally, `save_dataflow_definition` sets `loadEnabled: false` in queryMetadata — this controls whether data is staged during transformations, not destination configuration. The platform reconciles both issues on refresh ONLY when using `ApplyChangesIfNeeded`.
 
 | Refresh Option | Behavior on MCP-created dataflow |
 |---|---|
@@ -296,7 +296,7 @@ Requires a Web connection to the SharePoint site URL. Find via `list_connections
 | Credentials error on Lakehouse | Connection not bound | `add_connection_to_dataflow` then validate |
 | FastCopy fails with transforms | `Table.Group`, `NestedJoin`, etc. | Remove `[StagingDefinition]` |
 | Instant refresh fail (0-3s) | Privacy firewall or unpublished | `[AllowCombine = true]` and/or `ApplyChangesIfNeeded` |
-| `loadEnabled: false` in metadata | Normal MCP tool behavior | Not a problem with `DataDestinations` + `ApplyChangesIfNeeded` |
+| `loadEnabled: false` in metadata | Controls data staging during transforms, not destinations | Not a problem with `DataDestinations` + `ApplyChangesIfNeeded` |
 
 ---
 

--- a/claude-skills/datafactory-destinations.md
+++ b/claude-skills/datafactory-destinations.md
@@ -170,6 +170,30 @@ shared JoinedOutput = let ... in ...;
 
 **Critical:** This is REQUIRED for any dataflow that mixes source types. Single-source dataflows (e.g. Lakehouse-only) do not need it.
 
+### Multi-Source via API: Requirements
+
+Multi-source dataflows (e.g. Lakehouse + SharePoint/Web) **work via API** with `[AllowCombine = true]`, but require specific conditions:
+
+1. **Fresh dataflow** — Always create a new dataflow for multi-source. Never transition a previously-published single-source dataflow to multi-source; stale connection metadata persists and causes instant refresh failure.
+2. **Consolidated Lakehouse reads** — Read all Lakehouse tables in a single source query (one `Lakehouse.Contents` call), not separate queries per table. This reduces the number of distinct data source contexts the privacy firewall must reconcile.
+3. **All connections bound** — Add all connections (Lakehouse, Web/SharePoint) via `add_connection_to_dataflow` before and after `save_dataflow_definition`.
+4. **`ApplyChangesIfNeeded`** — Required on first refresh of any API-created dataflow.
+
+**Pattern that works:**
+```
+StoreActuals     → Single query: Lakehouse.Contents → reads orders, items, stores, products, categories → aggregates
+StoreTargets     → Excel.Workbook(Web.Contents("...sharepoint.com/.../file.xlsx"))
+StoreAnnotations → Excel.Workbook(Web.Contents("...sharepoint.com/.../file.xlsx"))
+OutputQuery      → Joins StoreActuals + StoreTargets + StoreAnnotations, with DataDestination attached
+```
+
+**What causes failure:**
+| Scenario | Result |
+|----------|--------|
+| Fresh dataflow + consolidated reads + AllowCombine | Works |
+| Previously-published single-source dataflow converted to multi-source | Instant failure — stale metadata |
+| Separate `Lakehouse.Contents` calls per source query | May fail — multiple data source contexts |
+
 ### MCP Tool Workflow
 
 ```
@@ -297,6 +321,9 @@ Requires a Web connection to the SharePoint site URL. Find via `list_connections
 | FastCopy fails with transforms | `Table.Group`, `NestedJoin`, etc. | Remove `[StagingDefinition]` |
 | Instant refresh fail (0-3s) | Privacy firewall or unpublished | `[AllowCombine = true]` and/or `ApplyChangesIfNeeded` |
 | `loadEnabled: false` in metadata | Controls data staging during transforms, not destinations | Not a problem with `DataDestinations` + `ApplyChangesIfNeeded` |
+| Multi-source instant fail via API | Dirty dataflow (converted from single-source) or separate Lakehouse.Contents calls | Create fresh dataflow; consolidate Lakehouse reads into single query |
+| Lakehouse-only fails after multi-source revert | `save_dataflow_definition` does NOT remove stale connections from queryMetadata | Create a new dataflow instead of reverting; no `remove_connection` tool exists |
+| `IsNewTarget = false` fails on API-created dataflow | Direct `[Data]` navigation + `IsNewTarget = false` fails on first refresh | Always use `IsNewTarget = true` with `?[Data]?` null-safe operators, even for existing tables |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Corrected AllowCombine documentation**: `[AllowCombine = true]` works via API on fresh dataflows with consolidated Lakehouse reads. Previous documentation incorrectly stated this was a platform limitation.
- **Added multi-source requirements**: Fresh dataflow (never reuse published single-source), consolidated `Lakehouse.Contents` calls, re-add connections after save, `ApplyChangesIfNeeded` on first refresh.
- **Added pitfall entries**: Dirty dataflow state, stale connections after `save_dataflow_definition`, `IsNewTarget = false` failure on API-created dataflows.
- **Updated tool references**: `validate_and_save_m_document` → `save_dataflow_definition`, `get_decoded_dataflow_definition` → `get_dataflow_definition`.
- **Replaced Manual with Automatic** for new table DataDestination settings (Manual causes `DestinationColumnNotFound`).

## Test plan
- [x] Created fresh multi-source dataflow via API with AllowCombine — refresh succeeded
- [x] Verified consolidated Lakehouse reads pattern matches working Copilot-generated dataflow
- [x] Confirmed dirty dataflow (single-source → multi-source conversion) causes instant failure
- [x] Confirmed `IsNewTarget = true` with null-safe operators required for API-created dataflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)