### PR TITLE
feat: Add Copy Job MCP tools behind flag --copy-job

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -10,6 +10,8 @@
 				"--",
 				"--pipeline",
 				"true",
+				"--copy-job",
+				"true",
 				"--dataflow-query",
 				"true"
 			]

--- a/DataFactory.MCP.Core/Abstractions/Interfaces/IFabricCopyJobService.cs
+++ b/DataFactory.MCP.Core/Abstractions/Interfaces/IFabricCopyJobService.cs
@@ -1,0 +1,88 @@
+using DataFactory.MCP.Models.CopyJob;
+using DataFactory.MCP.Models.CopyJob.Definition;
+using DataFactory.MCP.Models.Pipeline;
+using DataFactory.MCP.Models.Pipeline.Schedule;
+
+namespace DataFactory.MCP.Abstractions.Interfaces;
+
+/// <summary>
+/// Service for interacting with Microsoft Fabric Copy Jobs API
+/// </summary>
+public interface IFabricCopyJobService
+{
+    /// <summary>
+    /// Lists all copy jobs from the specified workspace
+    /// </summary>
+    Task<ListCopyJobsResponse> ListCopyJobsAsync(
+        string workspaceId,
+        string? continuationToken = null);
+
+    /// <summary>
+    /// Creates a new copy job in the specified workspace
+    /// </summary>
+    Task<CreateCopyJobResponse> CreateCopyJobAsync(
+        string workspaceId,
+        CreateCopyJobRequest request);
+
+    /// <summary>
+    /// Gets copy job metadata by ID
+    /// </summary>
+    Task<CopyJob> GetCopyJobAsync(
+        string workspaceId,
+        string copyJobId);
+
+    /// <summary>
+    /// Gets the definition of a copy job
+    /// </summary>
+    Task<CopyJobDefinition> GetCopyJobDefinitionAsync(
+        string workspaceId,
+        string copyJobId);
+
+    /// <summary>
+    /// Updates copy job metadata (displayName, description)
+    /// </summary>
+    Task<CopyJob> UpdateCopyJobAsync(
+        string workspaceId,
+        string copyJobId,
+        UpdateCopyJobRequest request);
+
+    /// <summary>
+    /// Updates a copy job definition
+    /// </summary>
+    Task UpdateCopyJobDefinitionAsync(
+        string workspaceId,
+        string copyJobId,
+        CopyJobDefinition definition);
+
+    /// <summary>
+    /// Runs a copy job on demand. Returns the Location header URL for tracking the job instance.
+    /// </summary>
+    Task<string?> RunCopyJobAsync(
+        string workspaceId,
+        string copyJobId,
+        object? executionData = null);
+
+    /// <summary>
+    /// Gets the status of a copy job instance
+    /// </summary>
+    Task<ItemJobInstance> GetCopyJobInstanceAsync(
+        string workspaceId,
+        string copyJobId,
+        string jobInstanceId);
+
+    /// <summary>
+    /// Creates a new schedule for a copy job
+    /// </summary>
+    Task<ItemSchedule> CreateCopyJobScheduleAsync(
+        string workspaceId,
+        string copyJobId,
+        CreateScheduleRequest request);
+
+    /// <summary>
+    /// Lists all schedules for a copy job
+    /// </summary>
+    Task<ListSchedulesResponse> ListCopyJobSchedulesAsync(
+        string workspaceId,
+        string copyJobId,
+        string? continuationToken = null);
+}

--- a/DataFactory.MCP.Core/Configuration/FeatureFlags.cs
+++ b/DataFactory.MCP.Core/Configuration/FeatureFlags.cs
@@ -30,4 +30,10 @@ public static class FeatureFlags
     /// Command line: --pipeline
     /// </summary>
     public const string Pipeline = "pipeline";
+
+    /// <summary>
+    /// Feature flag for enabling the CopyJobTool
+    /// Command line: --copy-job
+    /// </summary>
+    public const string CopyJob = "copy-job";
 }

--- a/DataFactory.MCP.Core/Extensions/CopyJobExtensions.cs
+++ b/DataFactory.MCP.Core/Extensions/CopyJobExtensions.cs
@@ -1,0 +1,25 @@
+using DataFactory.MCP.Models.CopyJob;
+
+namespace DataFactory.MCP.Extensions;
+
+/// <summary>
+/// Extension methods for CopyJob model transformations.
+/// </summary>
+public static class CopyJobExtensions
+{
+    /// <summary>
+    /// Formats a CopyJob object for MCP API responses.
+    /// </summary>
+    public static object ToFormattedInfo(this CopyJob copyJob)
+    {
+        return new
+        {
+            Id = copyJob.Id,
+            DisplayName = copyJob.DisplayName,
+            Description = copyJob.Description,
+            Type = copyJob.Type,
+            WorkspaceId = copyJob.WorkspaceId,
+            FolderId = copyJob.FolderId
+        };
+    }
+}

--- a/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using DataFactory.MCP.Services.DMTSv2;
 using DataFactory.MCP.Services.Notifications;
 using DataFactory.MCP.Tools;
 using DataFactory.MCP.Tools.Dataflow;
+using DataFactory.MCP.Tools.CopyJob;
 using DataFactory.MCP.Tools.Pipeline;
 
 namespace DataFactory.MCP.Extensions;
@@ -66,6 +67,8 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IFabricCapacityService, FabricCapacityService>()
             // Pipeline service
             .AddSingleton<IFabricPipelineService, FabricPipelineService>()
+            // Copy Job service
+            .AddSingleton<IFabricCopyJobService, FabricCopyJobService>()
             // Session accessor for background notifications
             .AddSingleton<IMcpSessionAccessor, McpSessionAccessor>()
             // Background task system (consolidated: monitor handles start, track, poll, notify)
@@ -144,6 +147,14 @@ public static class ServiceCollectionExtensions
             args,
             FeatureFlags.Pipeline,
             nameof(PipelineTool),
+            logger);
+
+        // Conditionally enable CopyJobTool based on feature flag
+        mcpBuilder.RegisterToolWithFeatureFlag<CopyJobTool>(
+            configuration,
+            args,
+            FeatureFlags.CopyJob,
+            nameof(CopyJobTool),
             logger);
 
         return mcpBuilder;

--- a/DataFactory.MCP.Core/Models/CopyJob/CopyJob.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/CopyJob.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob;
+
+/// <summary>
+/// Represents a Copy Job object in Microsoft Fabric
+/// </summary>
+public class CopyJob
+{
+    /// <summary>
+    /// The item ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item display name
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item description
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The item type
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The workspace ID
+    /// </summary>
+    [JsonPropertyName("workspaceId")]
+    public string WorkspaceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The folder ID
+    /// </summary>
+    [JsonPropertyName("folderId")]
+    public string? FolderId { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/CreateCopyJobRequest.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/CreateCopyJobRequest.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob;
+
+/// <summary>
+/// Create Copy Job request payload
+/// </summary>
+public class CreateCopyJobRequest
+{
+    /// <summary>
+    /// The Copy Job display name. The display name must follow naming rules according to item type.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [Required(ErrorMessage = "Display name is required")]
+    [StringLength(256, ErrorMessage = "Display name cannot exceed 256 characters")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Copy Job description. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [StringLength(256, ErrorMessage = "Description cannot exceed 256 characters")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The folder ID. If not specified or null, the Copy Job is created with the workspace as its folder.
+    /// </summary>
+    [JsonPropertyName("folderId")]
+    public string? FolderId { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/CreateCopyJobResponse.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/CreateCopyJobResponse.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob;
+
+/// <summary>
+/// Create Copy Job response
+/// </summary>
+public class CreateCopyJobResponse
+{
+    /// <summary>
+    /// The item ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item display name
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item description
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The item type
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The workspace ID
+    /// </summary>
+    [JsonPropertyName("workspaceId")]
+    public string WorkspaceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The folder ID
+    /// </summary>
+    [JsonPropertyName("folderId")]
+    public string? FolderId { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/Definition/CopyJobDefinition.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/Definition/CopyJobDefinition.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob.Definition;
+
+/// <summary>
+/// Copy Job public definition object
+/// </summary>
+public class CopyJobDefinition
+{
+    /// <summary>
+    /// A list of definition parts
+    /// </summary>
+    [JsonPropertyName("parts")]
+    [Required(ErrorMessage = "Definition parts are required")]
+    public List<CopyJobDefinitionPart> Parts { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/Definition/CopyJobDefinitionPart.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/Definition/CopyJobDefinitionPart.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob.Definition;
+
+/// <summary>
+/// Copy Job definition part object
+/// </summary>
+public class CopyJobDefinitionPart
+{
+    /// <summary>
+    /// The Copy Job public definition part path
+    /// </summary>
+    [JsonPropertyName("path")]
+    [Required(ErrorMessage = "Path is required")]
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Copy Job public definition part payload (base64 encoded)
+    /// </summary>
+    [JsonPropertyName("payload")]
+    [Required(ErrorMessage = "Payload is required")]
+    public string Payload { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The payload type
+    /// </summary>
+    [JsonPropertyName("payloadType")]
+    public string PayloadType { get; set; } = "InlineBase64";
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/Definition/GetCopyJobDefinitionResponse.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/Definition/GetCopyJobDefinitionResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob.Definition;
+
+/// <summary>
+/// Internal class for HTTP response deserialization when fetching copy job definitions
+/// </summary>
+internal sealed class GetCopyJobDefinitionResponse
+{
+    [JsonPropertyName("definition")]
+    public CopyJobDefinition Definition { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/Definition/UpdateCopyJobDefinitionRequest.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/Definition/UpdateCopyJobDefinitionRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob.Definition;
+
+/// <summary>
+/// Request model for updating copy job definition
+/// </summary>
+public class UpdateCopyJobDefinitionRequest
+{
+    /// <summary>
+    /// The definition to update
+    /// </summary>
+    [JsonPropertyName("definition")]
+    public CopyJobDefinition Definition { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/ListCopyJobsResponse.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/ListCopyJobsResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob;
+
+/// <summary>
+/// Response model for listing copy jobs
+/// </summary>
+public class ListCopyJobsResponse
+{
+    /// <summary>
+    /// A list of Copy Jobs
+    /// </summary>
+    [JsonPropertyName("value")]
+    public List<CopyJob> Value { get; set; } = new();
+
+    /// <summary>
+    /// The token for the next result set batch. If there are no more records, it's removed from the response.
+    /// </summary>
+    [JsonPropertyName("continuationToken")]
+    public string? ContinuationToken { get; set; }
+
+    /// <summary>
+    /// The URI of the next result set batch. If there are no more records, it's removed from the response.
+    /// </summary>
+    [JsonPropertyName("continuationUri")]
+    public string? ContinuationUri { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/CopyJob/UpdateCopyJobRequest.cs
+++ b/DataFactory.MCP.Core/Models/CopyJob/UpdateCopyJobRequest.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.CopyJob;
+
+/// <summary>
+/// Update Copy Job request payload
+/// </summary>
+public class UpdateCopyJobRequest
+{
+    /// <summary>
+    /// The Copy Job display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [StringLength(256, ErrorMessage = "Display name cannot exceed 256 characters")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The Copy Job description. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [StringLength(256, ErrorMessage = "Description cannot exceed 256 characters")]
+    public string? Description { get; set; }
+}

--- a/DataFactory.MCP.Core/Services/FabricCopyJobService.cs
+++ b/DataFactory.MCP.Core/Services/FabricCopyJobService.cs
@@ -1,0 +1,324 @@
+using DataFactory.MCP.Abstractions;
+using DataFactory.MCP.Abstractions.Interfaces;
+using DataFactory.MCP.Infrastructure.Http;
+using DataFactory.MCP.Models.CopyJob;
+using DataFactory.MCP.Models.CopyJob.Definition;
+using DataFactory.MCP.Models.Pipeline;
+using DataFactory.MCP.Models.Pipeline.Schedule;
+using Microsoft.Extensions.Logging;
+
+namespace DataFactory.MCP.Services;
+
+/// <summary>
+/// Service for interacting with Microsoft Fabric Copy Jobs API
+/// </summary>
+public class FabricCopyJobService : FabricServiceBase, IFabricCopyJobService
+{
+    public FabricCopyJobService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<FabricCopyJobService> logger,
+        IValidationService validationService)
+        : base(httpClientFactory, logger, validationService)
+    {
+    }
+
+    public async Task<ListCopyJobsResponse> ListCopyJobsAsync(
+        string workspaceId,
+        string? continuationToken = null)
+    {
+        try
+        {
+            ValidateGuids((workspaceId, nameof(workspaceId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/copyJobs")
+                .BuildEndpoint();
+            Logger.LogInformation("Fetching copy jobs from workspace {WorkspaceId}", workspaceId);
+
+            var response = await GetAsync<ListCopyJobsResponse>(endpoint, continuationToken);
+
+            Logger.LogInformation("Successfully retrieved {Count} copy jobs from workspace {WorkspaceId}",
+                response?.Value?.Count ?? 0, workspaceId);
+            return response ?? new ListCopyJobsResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching copy jobs from workspace {WorkspaceId}", workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<CreateCopyJobResponse> CreateCopyJobAsync(
+        string workspaceId,
+        CreateCopyJobRequest request)
+    {
+        try
+        {
+            ValidateGuids((workspaceId, nameof(workspaceId)));
+            ValidationService.ValidateAndThrow(request, nameof(request));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/copyJobs")
+                .BuildEndpoint();
+            Logger.LogInformation("Creating copy job '{DisplayName}' in workspace {WorkspaceId}",
+                request.DisplayName, workspaceId);
+
+            var createResponse = await PostAsync<CreateCopyJobResponse>(endpoint, request);
+
+            Logger.LogInformation("Successfully created copy job '{DisplayName}' with ID {CopyJobId} in workspace {WorkspaceId}",
+                request.DisplayName, createResponse?.Id, workspaceId);
+
+            return createResponse ?? new CreateCopyJobResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error creating copy job '{DisplayName}' in workspace {WorkspaceId}",
+                request?.DisplayName, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<CopyJob> GetCopyJobAsync(
+        string workspaceId,
+        string copyJobId)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/copyJobs/{copyJobId}")
+                .BuildEndpoint();
+            Logger.LogInformation("Fetching copy job {CopyJobId} from workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var copyJob = await GetAsync<CopyJob>(endpoint);
+
+            Logger.LogInformation("Successfully retrieved copy job {CopyJobId}", copyJobId);
+            return copyJob ?? throw new InvalidOperationException($"Copy job {copyJobId} not found");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching copy job {CopyJobId} from workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<CopyJobDefinition> GetCopyJobDefinitionAsync(
+        string workspaceId,
+        string copyJobId)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/getDefinition")
+                .BuildEndpoint();
+            Logger.LogInformation("Getting definition for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var emptyRequest = new { };
+            var response = await PostAsync<GetCopyJobDefinitionResponse>(endpoint, emptyRequest)
+                           ?? throw new InvalidOperationException("Failed to get copy job definition response");
+
+            Logger.LogInformation("Successfully retrieved definition for copy job {CopyJobId}", copyJobId);
+            return response.Definition;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error getting definition for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<CopyJob> UpdateCopyJobAsync(
+        string workspaceId,
+        string copyJobId,
+        UpdateCopyJobRequest request)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/copyJobs/{copyJobId}")
+                .BuildEndpoint();
+            Logger.LogInformation("Updating copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var copyJob = await PatchAsync<CopyJob>(endpoint, request);
+
+            Logger.LogInformation("Successfully updated copy job {CopyJobId}", copyJobId);
+            return copyJob ?? throw new InvalidOperationException($"Failed to update copy job {copyJobId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task UpdateCopyJobDefinitionAsync(
+        string workspaceId,
+        string copyJobId,
+        CopyJobDefinition definition)
+    {
+        ValidateGuids(
+            (workspaceId, nameof(workspaceId)),
+            (copyJobId, nameof(copyJobId)));
+
+        var endpoint = FabricUrlBuilder.ForFabricApi()
+            .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/updateDefinition")
+            .BuildEndpoint();
+        var request = new UpdateCopyJobDefinitionRequest { Definition = definition };
+
+        Logger.LogInformation("Updating copy job definition for {CopyJobId}", copyJobId);
+
+        var success = await PostNoContentAsync(endpoint, request);
+
+        if (!success)
+        {
+            throw new HttpRequestException($"Failed to update copy job definition for {copyJobId}");
+        }
+
+        Logger.LogInformation("Successfully updated copy job definition for {CopyJobId}", copyJobId);
+    }
+
+    private const string CopyJobType = "CopyJob";
+
+    public async Task<string?> RunCopyJobAsync(
+        string workspaceId,
+        string copyJobId,
+        object? executionData = null)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/jobs/{CopyJobType}/instances")
+                .BuildEndpoint();
+            Logger.LogInformation("Running copy job {CopyJobId} on demand in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var request = executionData != null ? new { executionData } : null;
+            var location = await PostAndGetLocationAsync(endpoint, request);
+
+            Logger.LogInformation("Copy job {CopyJobId} run triggered successfully. Location: {Location}",
+                copyJobId, location);
+            return location;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error running copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<ItemJobInstance> GetCopyJobInstanceAsync(
+        string workspaceId,
+        string copyJobId,
+        string jobInstanceId)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)),
+                (jobInstanceId, nameof(jobInstanceId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/jobs/instances/{jobInstanceId}")
+                .BuildEndpoint();
+            Logger.LogInformation("Getting job instance {JobInstanceId} for copy job {CopyJobId} in workspace {WorkspaceId}",
+                jobInstanceId, copyJobId, workspaceId);
+
+            var jobInstance = await GetAsync<ItemJobInstance>(endpoint);
+
+            Logger.LogInformation("Successfully retrieved job instance {JobInstanceId} with status {Status}",
+                jobInstanceId, jobInstance?.Status);
+            return jobInstance ?? throw new InvalidOperationException($"Job instance {jobInstanceId} not found");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error getting job instance {JobInstanceId} for copy job {CopyJobId} in workspace {WorkspaceId}",
+                jobInstanceId, copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<ItemSchedule> CreateCopyJobScheduleAsync(
+        string workspaceId,
+        string copyJobId,
+        CreateScheduleRequest request)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/jobs/{CopyJobType}/schedules")
+                .BuildEndpoint();
+            Logger.LogInformation("Creating schedule for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var schedule = await PostAsync<ItemSchedule>(endpoint, request);
+
+            Logger.LogInformation("Successfully created schedule {ScheduleId} for copy job {CopyJobId}",
+                schedule?.Id, copyJobId);
+            return schedule ?? throw new InvalidOperationException("Failed to create copy job schedule");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error creating schedule for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<ListSchedulesResponse> ListCopyJobSchedulesAsync(
+        string workspaceId,
+        string copyJobId,
+        string? continuationToken = null)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (copyJobId, nameof(copyJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/items/{copyJobId}/jobs/{CopyJobType}/schedules")
+                .BuildEndpoint();
+            Logger.LogInformation("Listing schedules for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+
+            var response = await GetAsync<ListSchedulesResponse>(endpoint, continuationToken);
+
+            Logger.LogInformation("Successfully retrieved {Count} schedules for copy job {CopyJobId}",
+                response?.Value?.Count ?? 0, copyJobId);
+            return response ?? new ListSchedulesResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error listing schedules for copy job {CopyJobId} in workspace {WorkspaceId}",
+                copyJobId, workspaceId);
+            throw;
+        }
+    }
+}

--- a/DataFactory.MCP.Core/Tools/CopyJob/CopyJobTool.cs
+++ b/DataFactory.MCP.Core/Tools/CopyJob/CopyJobTool.cs
@@ -365,7 +365,7 @@ public class CopyJobTool
                 WorkspaceId = workspaceId,
                 JobInstanceId = jobInstanceId,
                 LocationUrl = location,
-                Hint = "Use GetCopyJobRunStatusAsync with the jobInstanceId to check the run status"
+                Hint = "Use the 'get_copy_job_run_status' MCP tool with the jobInstanceId to check the run status"
             };
 
             return result.ToMcpJson();

--- a/DataFactory.MCP.Core/Tools/CopyJob/CopyJobTool.cs
+++ b/DataFactory.MCP.Core/Tools/CopyJob/CopyJobTool.cs
@@ -1,0 +1,582 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using DataFactory.MCP.Abstractions.Interfaces;
+using DataFactory.MCP.Extensions;
+using DataFactory.MCP.Models.CopyJob;
+using DataFactory.MCP.Models.CopyJob.Definition;
+using DataFactory.MCP.Models.Pipeline.Schedule;
+
+namespace DataFactory.MCP.Tools.CopyJob;
+
+/// <summary>
+/// MCP Tool for managing Microsoft Fabric Copy Jobs.
+/// Handles CRUD operations and definition management.
+/// </summary>
+[McpServerToolType]
+public class CopyJobTool
+{
+    private readonly IFabricCopyJobService _copyJobService;
+    private readonly IValidationService _validationService;
+
+    public CopyJobTool(
+        IFabricCopyJobService copyJobService,
+        IValidationService validationService)
+    {
+        _copyJobService = copyJobService;
+        _validationService = validationService;
+    }
+
+    [McpServerTool, Description(@"Returns a list of Copy Jobs from the specified workspace. This API supports pagination.")]
+    public async Task<string> ListCopyJobsAsync(
+        [Description("The workspace ID to list copy jobs from (required)")] string workspaceId,
+        [Description("A token for retrieving the next page of results (optional)")] string? continuationToken = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+
+            var response = await _copyJobService.ListCopyJobsAsync(workspaceId, continuationToken);
+
+            if (!response.Value.Any())
+            {
+                return $"No copy jobs found in workspace '{workspaceId}'.";
+            }
+
+            var result = new
+            {
+                WorkspaceId = workspaceId,
+                CopyJobCount = response.Value.Count,
+                ContinuationToken = response.ContinuationToken,
+                ContinuationUri = response.ContinuationUri,
+                HasMoreResults = !string.IsNullOrEmpty(response.ContinuationToken),
+                CopyJobs = response.Value.Select(c => c.ToFormattedInfo())
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("listing copy jobs").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Creates a Copy Job in the specified workspace.")]
+    public async Task<string> CreateCopyJobAsync(
+        [Description("The workspace ID where the copy job will be created (required)")] string workspaceId,
+        [Description("The Copy Job display name (required)")] string displayName,
+        [Description("The Copy Job description (optional, max 256 characters)")] string? description = null,
+        [Description("The folder ID where the copy job will be created (optional, defaults to workspace root)")] string? folderId = null)
+    {
+        try
+        {
+            var request = new CreateCopyJobRequest
+            {
+                DisplayName = displayName,
+                Description = description,
+                FolderId = folderId
+            };
+
+            var response = await _copyJobService.CreateCopyJobAsync(workspaceId, request);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Copy job '{displayName}' created successfully",
+                CopyJobId = response.Id,
+                DisplayName = response.DisplayName,
+                Description = response.Description,
+                Type = response.Type,
+                WorkspaceId = response.WorkspaceId,
+                FolderId = response.FolderId,
+                CreatedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("creating copy job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Gets the metadata of a Copy Job by ID.")]
+    public async Task<string> GetCopyJobAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to retrieve (required)")] string copyJobId)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+
+            var copyJob = await _copyJobService.GetCopyJobAsync(workspaceId, copyJobId);
+
+            return copyJob.ToFormattedInfo().ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("getting copy job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Gets the definition of a Copy Job. The definition contains the copy job JSON configuration with base64-encoded parts.")]
+    public async Task<string> GetCopyJobDefinitionAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to get the definition for (required)")] string copyJobId)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+
+            var definition = await _copyJobService.GetCopyJobDefinitionAsync(workspaceId, copyJobId);
+
+            var result = new
+            {
+                Success = true,
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                PartsCount = definition.Parts.Count,
+                Parts = definition.Parts.Select(p => new
+                {
+                    Path = p.Path,
+                    PayloadType = p.PayloadType,
+                    DecodedPayload = TryDecodeBase64(p.Payload)
+                })
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("getting copy job definition").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Updates the metadata (displayName and/or description) of a Copy Job.")]
+    public async Task<string> UpdateCopyJobAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to update (required)")] string copyJobId,
+        [Description("The new display name (optional)")] string? displayName = null,
+        [Description("The new description (optional)")] string? description = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+
+            if (string.IsNullOrEmpty(displayName) && description == null)
+            {
+                throw new ArgumentException("At least one of displayName or description must be provided");
+            }
+
+            var request = new UpdateCopyJobRequest
+            {
+                DisplayName = displayName,
+                Description = description
+            };
+
+            var copyJob = await _copyJobService.UpdateCopyJobAsync(workspaceId, copyJobId, request);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Copy job '{copyJob.DisplayName}' updated successfully",
+                CopyJob = copyJob.ToFormattedInfo()
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("updating copy job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Updates the definition of a Copy Job with the provided JSON content. The JSON will be base64-encoded and sent to the API.")]
+    public async Task<string> UpdateCopyJobDefinitionAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to update (required)")] string copyJobId,
+        [Description("The copy job definition JSON content (required)")] string definitionJson)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+            _validationService.ValidateRequiredString(definitionJson, nameof(definitionJson));
+
+            // Validate JSON format
+            try
+            {
+                JsonDocument.Parse(definitionJson);
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException($"Invalid JSON format: {ex.Message}");
+            }
+
+            // Encode the JSON as base64
+            var base64Payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(definitionJson));
+
+            var definition = new CopyJobDefinition
+            {
+                Parts = new List<CopyJobDefinitionPart>
+                {
+                    new CopyJobDefinitionPart
+                    {
+                        Path = "copyjob-content.json",
+                        Payload = base64Payload,
+                        PayloadType = "InlineBase64"
+                    }
+                }
+            };
+
+            await _copyJobService.UpdateCopyJobDefinitionAsync(workspaceId, copyJobId, definition);
+
+            var result = new
+            {
+                Success = true,
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                Message = $"Copy job definition updated successfully"
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("updating copy job definition").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Runs a Copy Job on demand. Returns a job instance ID that can be used to track the run status with GetCopyJobRunStatusAsync.")]
+    public async Task<string> RunCopyJobAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to run (required)")] string copyJobId,
+        [Description("Optional execution data as JSON string for parameterized copy job runs (optional)")] string? executionDataJson = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+
+            object? executionData = null;
+            if (!string.IsNullOrEmpty(executionDataJson))
+            {
+                try
+                {
+                    executionData = JsonSerializer.Deserialize<object>(executionDataJson);
+                }
+                catch (JsonException ex)
+                {
+                    throw new ArgumentException($"Invalid executionData JSON format: {ex.Message}");
+                }
+            }
+
+            var location = await _copyJobService.RunCopyJobAsync(workspaceId, copyJobId, executionData);
+
+            // Extract job instance ID from the Location header URL
+            string? jobInstanceId = null;
+            if (!string.IsNullOrEmpty(location))
+            {
+                var segments = new Uri(location).Segments;
+                jobInstanceId = segments.LastOrDefault()?.TrimEnd('/');
+            }
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Copy job run triggered successfully",
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                JobInstanceId = jobInstanceId,
+                LocationUrl = location,
+                Hint = "Use GetCopyJobRunStatusAsync with the jobInstanceId to check the run status"
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("running copy job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Gets the status of a Copy Job run (job instance). Use the jobInstanceId returned from RunCopyJobAsync to check the run status. Possible statuses: NotStarted, InProgress, Completed, Failed, Cancelled, Deduped.")]
+    public async Task<string> GetCopyJobRunStatusAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID (required)")] string copyJobId,
+        [Description("The job instance ID returned from RunCopyJobAsync (required)")] string jobInstanceId)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+            _validationService.ValidateRequiredString(jobInstanceId, nameof(jobInstanceId));
+
+            var jobInstance = await _copyJobService.GetCopyJobInstanceAsync(workspaceId, copyJobId, jobInstanceId);
+
+            var result = new
+            {
+                Success = true,
+                JobInstanceId = jobInstance.Id,
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                JobType = jobInstance.JobType,
+                InvokeType = jobInstance.InvokeType,
+                Status = jobInstance.Status,
+                StartTimeUtc = jobInstance.StartTimeUtc,
+                EndTimeUtc = jobInstance.EndTimeUtc,
+                FailureReason = jobInstance.FailureReason
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("getting copy job run status").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Creates a schedule for a Copy Job. Supports Cron (interval-based), Daily, Weekly, and Monthly schedule types. An item can have up to 20 schedules.")]
+    public async Task<string> CreateCopyJobScheduleAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to schedule (required)")] string copyJobId,
+        [Description("Whether the schedule is enabled (required)")] bool enabled,
+        [Description(@"The schedule configuration as JSON string (required). Supported types:
+- Cron: {""type"":""Cron"",""startDateTime"":""2024-04-28T00:00:00"",""endDateTime"":""2024-04-30T23:59:00"",""localTimeZoneId"":""Central Standard Time"",""interval"":10}
+- Daily: {""type"":""Daily"",""startDateTime"":""..."",""endDateTime"":""..."",""localTimeZoneId"":""..."",""times"":[""08:00"",""16:00""]}
+- Weekly: {""type"":""Weekly"",""startDateTime"":""..."",""endDateTime"":""..."",""localTimeZoneId"":""..."",""weekdays"":[""Monday"",""Wednesday""],""times"":[""09:00""]}
+- Monthly: {""type"":""Monthly"",""startDateTime"":""..."",""endDateTime"":""..."",""localTimeZoneId"":""..."",""occurrence"":{""occurrenceType"":""DayOfMonth"",""dayOfMonth"":15},""recurrence"":1,""times"":[""10:00""]}")] string configurationJson)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+            _validationService.ValidateRequiredString(configurationJson, nameof(configurationJson));
+
+            object configuration;
+            try
+            {
+                configuration = JsonSerializer.Deserialize<object>(configurationJson)
+                    ?? throw new ArgumentException("Configuration JSON cannot be null");
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException($"Invalid configuration JSON format: {ex.Message}");
+            }
+
+            var request = new CreateScheduleRequest
+            {
+                Enabled = enabled,
+                Configuration = configuration
+            };
+
+            var schedule = await _copyJobService.CreateCopyJobScheduleAsync(workspaceId, copyJobId, request);
+
+            var result = new
+            {
+                Success = true,
+                Message = "Copy job schedule created successfully",
+                ScheduleId = schedule.Id,
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                Enabled = schedule.Enabled,
+                CreatedDateTime = schedule.CreatedDateTime,
+                Configuration = schedule.Configuration,
+                Owner = schedule.Owner
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("creating copy job schedule").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Lists all schedules for a Copy Job. Returns the schedule configurations, status, and owner information.")]
+    public async Task<string> ListCopyJobSchedulesAsync(
+        [Description("The workspace ID containing the copy job (required)")] string workspaceId,
+        [Description("The copy job ID to list schedules for (required)")] string copyJobId,
+        [Description("A token for retrieving the next page of results (optional)")] string? continuationToken = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(copyJobId, nameof(copyJobId));
+
+            var response = await _copyJobService.ListCopyJobSchedulesAsync(workspaceId, copyJobId, continuationToken);
+
+            if (!response.Value.Any())
+            {
+                return $"No schedules found for copy job '{copyJobId}' in workspace '{workspaceId}'.";
+            }
+
+            var result = new
+            {
+                CopyJobId = copyJobId,
+                WorkspaceId = workspaceId,
+                ScheduleCount = response.Value.Count,
+                ContinuationToken = response.ContinuationToken,
+                ContinuationUri = response.ContinuationUri,
+                HasMoreResults = !string.IsNullOrEmpty(response.ContinuationToken),
+                Schedules = response.Value.Select(s => new
+                {
+                    Id = s.Id,
+                    Enabled = s.Enabled,
+                    CreatedDateTime = s.CreatedDateTime,
+                    Configuration = s.Configuration,
+                    Owner = s.Owner
+                })
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("listing copy job schedules").ToMcpJson();
+        }
+    }
+
+    /// <summary>
+    /// Attempts to decode a base64-encoded string. Returns the decoded string or the original payload if decoding fails.
+    /// </summary>
+    private static string? TryDecodeBase64(string? payload)
+    {
+        if (string.IsNullOrEmpty(payload))
+            return null;
+
+        try
+        {
+            var bytes = Convert.FromBase64String(payload);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch
+        {
+            return payload;
+        }
+    }
+}

--- a/DataFactory.MCP.Tests/Infrastructure/McpTestFixture.cs
+++ b/DataFactory.MCP.Tests/Infrastructure/McpTestFixture.cs
@@ -13,6 +13,7 @@ using DataFactory.MCP.Services.DMTSv2;
 using DataFactory.MCP.Services.Notifications;
 using DataFactory.MCP.Tools;
 using DataFactory.MCP.Tools.Dataflow;
+using DataFactory.MCP.Tools.CopyJob;
 using DataFactory.MCP.Tools.Pipeline;
 
 namespace DataFactory.MCP.Tests.Infrastructure;
@@ -86,6 +87,7 @@ public class McpTestFixture : IDisposable
                 services.AddScoped<IFabricDataflowService, FabricDataflowService>();
                 services.AddScoped<IFabricCapacityService, FabricCapacityService>();
                 services.AddScoped<IFabricPipelineService, FabricPipelineService>();
+                services.AddScoped<IFabricCopyJobService, FabricCopyJobService>();
 
                 // Register background task services
                 services.AddSingleton<IMcpSessionAccessor, McpSessionAccessor>();
@@ -105,6 +107,7 @@ public class McpTestFixture : IDisposable
                 services.AddScoped<DataflowQueryTool>();
                 services.AddScoped<DataflowDefinitionTool>();
                 services.AddScoped<PipelineTool>();
+                services.AddScoped<CopyJobTool>();
             })
             .Build();
 

--- a/DataFactory.MCP.Tests/Integration/CopyJobToolIntegrationTests.cs
+++ b/DataFactory.MCP.Tests/Integration/CopyJobToolIntegrationTests.cs
@@ -1,0 +1,668 @@
+using Xunit;
+using DataFactory.MCP.Tools.CopyJob;
+using DataFactory.MCP.Tests.Infrastructure;
+using System.Text.Json;
+using DataFactory.MCP.Models;
+
+namespace DataFactory.MCP.Tests.Integration;
+
+/// <summary>
+/// Integration tests for CopyJobTool that call the actual MCP tool methods
+/// without mocking to verify real behavior
+/// </summary>
+public class CopyJobToolIntegrationTests : FabricToolIntegrationTestBase
+{
+    private readonly CopyJobTool _copyJobTool;
+
+    // Test workspace IDs
+    private const string TestWorkspaceId = "349f40ea-ecb0-4fe6-baf4-884b2887b074";
+    private const string InvalidWorkspaceId = "invalid-workspace-id";
+    private const string InvalidCopyJobId = "00000000-0000-0000-0000-000000000001";
+    private const string InvalidJobInstanceId = "00000000-0000-0000-0000-000000000002";
+
+    public CopyJobToolIntegrationTests(McpTestFixture fixture) : base(fixture)
+    {
+        _copyJobTool = Fixture.GetService<CopyJobTool>();
+    }
+
+    #region DI Registration
+
+    [Fact]
+    public void CopyJobTool_ShouldBeRegisteredInDI()
+    {
+        // Assert
+        Assert.NotNull(_copyJobTool);
+        Assert.IsType<CopyJobTool>(_copyJobTool);
+    }
+
+    #endregion
+
+    #region ListCopyJobsAsync - Unauthenticated
+
+    [Fact]
+    public async Task ListCopyJobsAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync(TestWorkspaceId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListCopyJobsAsync_WithContinuationToken_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange
+        var testToken = "test-continuation-token";
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync(TestWorkspaceId, testToken);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListCopyJobsAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync("");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task ListCopyJobsAsync_WithNullWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync(null!);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    #endregion
+
+    #region GetCopyJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task GetCopyJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetCopyJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobAsync("", InvalidCopyJobId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task GetCopyJobAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobAsync(TestWorkspaceId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    #endregion
+
+    #region CreateCopyJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task CreateCopyJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.CreateCopyJobAsync(TestWorkspaceId, "test-copy-job");
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task CreateCopyJobAsync_WithEmptyDisplayName_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.CreateCopyJobAsync(TestWorkspaceId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result);
+    }
+
+    #endregion
+
+    #region UpdateCopyJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task UpdateCopyJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobAsync(TestWorkspaceId, InvalidCopyJobId, displayName: "updated");
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpdateCopyJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobAsync("", InvalidCopyJobId, displayName: "updated");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task UpdateCopyJobAsync_WithNoUpdates_ShouldReturnValidationError()
+    {
+        // Act - neither displayName nor description provided
+        var result = await _copyJobTool.UpdateCopyJobAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "At least one of displayName or description must be provided");
+    }
+
+    #endregion
+
+    #region GetCopyJobDefinitionAsync - Unauthenticated
+
+    [Fact]
+    public async Task GetCopyJobDefinitionAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobDefinitionAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetCopyJobDefinitionAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobDefinitionAsync("", InvalidCopyJobId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task GetCopyJobDefinitionAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobDefinitionAsync(TestWorkspaceId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    #endregion
+
+    #region UpdateCopyJobDefinitionAsync - Unauthenticated
+
+    [Fact]
+    public async Task UpdateCopyJobDefinitionAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange
+        var definitionJson = "{\"source\":{},\"destination\":{}}";
+
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobDefinitionAsync(TestWorkspaceId, InvalidCopyJobId, definitionJson);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpdateCopyJobDefinitionAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Arrange
+        var definitionJson = "{\"source\":{},\"destination\":{}}";
+
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobDefinitionAsync("", InvalidCopyJobId, definitionJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task UpdateCopyJobDefinitionAsync_WithInvalidJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobDefinitionAsync(TestWorkspaceId, InvalidCopyJobId, "not-valid-json{");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid JSON format");
+    }
+
+    [Fact]
+    public async Task UpdateCopyJobDefinitionAsync_WithEmptyDefinitionJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.UpdateCopyJobDefinitionAsync(TestWorkspaceId, InvalidCopyJobId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("definitionJson"));
+    }
+
+    #endregion
+
+    #region RunCopyJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task RunCopyJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task RunCopyJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync("", InvalidCopyJobId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task RunCopyJobAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync(TestWorkspaceId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    [Fact]
+    public async Task RunCopyJobAsync_WithInvalidExecutionDataJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync(TestWorkspaceId, InvalidCopyJobId, "not-valid-json{");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid executionData JSON format");
+    }
+
+    [Fact]
+    public async Task RunCopyJobAsync_WithValidExecutionDataJson_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange
+        var executionDataJson = "{\"param1\":\"value1\"}";
+
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync(TestWorkspaceId, InvalidCopyJobId, executionDataJson);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    #endregion
+
+    #region GetCopyJobRunStatusAsync - Unauthenticated
+
+    [Fact]
+    public async Task GetCopyJobRunStatusAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobRunStatusAsync(TestWorkspaceId, InvalidCopyJobId, InvalidJobInstanceId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetCopyJobRunStatusAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobRunStatusAsync("", InvalidCopyJobId, InvalidJobInstanceId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task GetCopyJobRunStatusAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobRunStatusAsync(TestWorkspaceId, "", InvalidJobInstanceId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    [Fact]
+    public async Task GetCopyJobRunStatusAsync_WithEmptyJobInstanceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.GetCopyJobRunStatusAsync(TestWorkspaceId, InvalidCopyJobId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("jobInstanceId"));
+    }
+
+    #endregion
+
+    #region CreateCopyJobScheduleAsync - Unauthenticated
+
+    [Fact]
+    public async Task CreateCopyJobScheduleAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange
+        var configJson = "{\"type\":\"Cron\",\"startDateTime\":\"2024-04-28T00:00:00\",\"endDateTime\":\"2024-04-30T23:59:00\",\"localTimeZoneId\":\"Central Standard Time\",\"interval\":10}";
+
+        // Act
+        var result = await _copyJobTool.CreateCopyJobScheduleAsync(TestWorkspaceId, InvalidCopyJobId, true, configJson);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task CreateCopyJobScheduleAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Arrange
+        var configJson = "{\"type\":\"Cron\",\"interval\":10}";
+
+        // Act
+        var result = await _copyJobTool.CreateCopyJobScheduleAsync("", InvalidCopyJobId, true, configJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task CreateCopyJobScheduleAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Arrange
+        var configJson = "{\"type\":\"Cron\",\"interval\":10}";
+
+        // Act
+        var result = await _copyJobTool.CreateCopyJobScheduleAsync(TestWorkspaceId, "", true, configJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    [Fact]
+    public async Task CreateCopyJobScheduleAsync_WithEmptyConfigurationJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.CreateCopyJobScheduleAsync(TestWorkspaceId, InvalidCopyJobId, true, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("configurationJson"));
+    }
+
+    [Fact]
+    public async Task CreateCopyJobScheduleAsync_WithInvalidConfigurationJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.CreateCopyJobScheduleAsync(TestWorkspaceId, InvalidCopyJobId, true, "not-valid-json{");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid configuration JSON format");
+    }
+
+    #endregion
+
+    #region ListCopyJobSchedulesAsync - Unauthenticated
+
+    [Fact]
+    public async Task ListCopyJobSchedulesAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListCopyJobSchedulesAsync_WithContinuationToken_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange
+        var testToken = "test-continuation-token";
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync(TestWorkspaceId, InvalidCopyJobId, testToken);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListCopyJobSchedulesAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync("", InvalidCopyJobId);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task ListCopyJobSchedulesAsync_WithEmptyCopyJobId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync(TestWorkspaceId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("copyJobId"));
+    }
+
+    #endregion
+
+    #region Authenticated Scenarios
+
+    [SkippableFact]
+    public async Task ListCopyJobsAsync_WithAuthentication_ShouldReturnResultOrApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync(TestWorkspaceId);
+
+        // Assert
+        AssertCopyJobListResult(result);
+    }
+
+    [SkippableFact]
+    public async Task ListCopyJobsAsync_WithInvalidWorkspaceId_ShouldReturnApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobsAsync(InvalidWorkspaceId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        AssertNoAuthenticationError(result);
+        Assert.Contains("workspaceId must be a valid GUID", result);
+    }
+
+    [SkippableFact]
+    public async Task GetCopyJobAsync_WithAuthentication_NonExistentCopyJob_ShouldReturnError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.GetCopyJobAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+    }
+
+    [SkippableFact]
+    public async Task RunCopyJobAsync_WithAuthentication_NonExistentCopyJob_ShouldReturnError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.RunCopyJobAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+    }
+
+    [SkippableFact]
+    public async Task GetCopyJobRunStatusAsync_WithAuthentication_NonExistentJobInstance_ShouldReturnError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.GetCopyJobRunStatusAsync(TestWorkspaceId, InvalidCopyJobId, InvalidJobInstanceId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+    }
+
+    [SkippableFact]
+    public async Task ListCopyJobSchedulesAsync_WithAuthentication_ShouldReturnResultOrApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync(TestWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        AssertScheduleListResult(result);
+    }
+
+    [SkippableFact]
+    public async Task ListCopyJobSchedulesAsync_WithInvalidWorkspaceId_ShouldReturnApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _copyJobTool.ListCopyJobSchedulesAsync(InvalidWorkspaceId, InvalidCopyJobId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        AssertNoAuthenticationError(result);
+        Assert.Contains("workspaceId must be a valid GUID", result);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static void AssertCopyJobListResult(string result)
+    {
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        // Skip if upstream service is blocking requests
+        SkipIfUpstreamBlocked(result);
+
+        AssertNoAuthenticationError(result);
+
+        // Should either be "No copy jobs found" or valid JSON
+        if (result.Contains("No copy jobs found"))
+        {
+            Assert.Contains("No copy jobs found", result);
+            return;
+        }
+
+        if (result.Contains("HttpRequestError"))
+        {
+            McpResponseAssertHelper.AssertHttpError(result);
+            return;
+        }
+
+        // If it's JSON, verify basic structure
+        if (IsValidJson(result))
+        {
+            var jsonDoc = JsonDocument.Parse(result);
+            var root = jsonDoc.RootElement;
+
+            Assert.True(root.TryGetProperty("workspaceId", out _), "JSON response should have workspaceId property");
+            Assert.True(root.TryGetProperty("copyJobCount", out _), "JSON response should have copyJobCount property");
+            Assert.True(root.TryGetProperty("copyJobs", out _), "JSON response should have copyJobs property");
+        }
+    }
+
+    private static void AssertScheduleListResult(string result)
+    {
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        // Skip if upstream service is blocking requests
+        SkipIfUpstreamBlocked(result);
+
+        AssertNoAuthenticationError(result);
+
+        // Should either be "No schedules found" or valid JSON
+        if (result.Contains("No schedules found"))
+        {
+            Assert.Contains("No schedules found", result);
+            return;
+        }
+
+        if (result.Contains("HttpRequestError"))
+        {
+            McpResponseAssertHelper.AssertHttpError(result);
+            return;
+        }
+
+        // If it's JSON, verify basic structure
+        if (IsValidJson(result))
+        {
+            var jsonDoc = JsonDocument.Parse(result);
+            var root = jsonDoc.RootElement;
+
+            Assert.True(root.TryGetProperty("copyJobId", out _), "JSON response should have copyJobId property");
+            Assert.True(root.TryGetProperty("workspaceId", out _), "JSON response should have workspaceId property");
+            Assert.True(root.TryGetProperty("scheduleCount", out _), "JSON response should have scheduleCount property");
+            Assert.True(root.TryGetProperty("schedules", out _), "JSON response should have schedules property");
+        }
+    }
+
+    #endregion
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server for Microsoft Fabric resource discovery an
 - **Workspace Management**: List and retrieve Microsoft Fabric workspaces
 - **Dataflow Management**: List, create, and retrieve Microsoft Fabric dataflows
 - **Pipeline Management**: List, create, update, run, monitor, and schedule Microsoft Fabric pipelines
+- **Copy Job Management**: List, create, update, run, monitor, and schedule Microsoft Fabric copy jobs
 - **Capacity Management**: List and retrieve Microsoft Fabric capacities
 - **Microsoft Fabric Integration**: Support for on-premises, personal, and virtual network gateways
 - 📦 **NuGet Distribution**: Available as a NuGet package for easy integration
@@ -31,6 +32,7 @@ A Model Context Protocol (MCP) server for Microsoft Fabric resource discovery an
 - **Dataflow Query Execution**: `execute_query` *(Preview)*
 - **Capacity Management**: `list_capacities`
 - **Pipeline Management**: `list_pipelines`, `create_pipeline`, `get_pipeline`, `update_pipeline`, `get_pipeline_definition`, `update_pipeline_definition`, `run_pipeline`, `get_pipeline_run_status`, `create_pipeline_schedule`, `list_pipeline_schedules` *(Preview)*
+- **Copy Job Management**: `list_copy_jobs`, `create_copy_job`, `get_copy_job`, `update_copy_job`, `get_copy_job_definition`, `update_copy_job_definition`, `run_copy_job`, `get_copy_job_run_status`, `create_copy_job_schedule`, `list_copy_job_schedules` *(Preview)*
 
 ## Available Resources
 
@@ -107,6 +109,7 @@ See the detailed guides for comprehensive usage instructions:
 - **Dataflow Management**: See [Dataflow Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/dataflow-management.md)
 - **Capacity Management**: See [Capacity Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/capacity-management.md)
 - **Pipeline Management**: See [Pipeline Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/pipeline-management.md)
+- **Copy Job Management**: See [Copy Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/copyjob-management.md)
 
 ## Development
 
@@ -189,6 +192,7 @@ For complete documentation, see our **[Documentation Index](https://github.com/m
 - **[Dataflow Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/dataflow-management.md)** - Dataflow operations and examples
 - **[Capacity Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/capacity-management.md)** - Capacity operations and examples
 - **[Pipeline Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/pipeline-management.md)** - Pipeline operations and examples
+- **[Copy Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/copyjob-management.md)** - Copy job operations and examples
 - **[Architecture Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/ARCHITECTURE.md)** - Technical architecture and design details
 
 ## Contributing

--- a/claude-skills/SKILL.md
+++ b/claude-skills/SKILL.md
@@ -55,4 +55,3 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 | `datafactory-performance.md` | Query timeouts, chunking, query folding, connector selection |
 | `datafactory-advanced.md` | Fast Copy limits, Action.Sequence, Modern Evaluator |
 | `datafactory-pipelines.md` | Creating pipelines, Dataflow activities, chaining, scheduling |
-| `datafactory-copyjobs.md` | Creating copy jobs, running, monitoring, scheduling |

--- a/claude-skills/SKILL.md
+++ b/claude-skills/SKILL.md
@@ -55,3 +55,4 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 | `datafactory-performance.md` | Query timeouts, chunking, query folding, connector selection |
 | `datafactory-advanced.md` | Fast Copy limits, Action.Sequence, Modern Evaluator |
 | `datafactory-pipelines.md` | Creating pipelines, Dataflow activities, chaining, scheduling |
+| `datafactory-copyjobs.md` | Creating copy jobs, running, monitoring, scheduling |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,10 @@ The Microsoft Data Factory MCP Server is a .NET-based application that implement
 │  │  │  Dataflow    │ │DataflowQuery │ │  Capacity    │ │ AzureRes   │  │   │
 │  │  │    Tool      │ │ Tool (flag)  │ │    Tool      │ │ Discovery  │  │   │
 │  │  └──────────────┘ └──────────────┘ └──────────────┘ └────────────┘  │   │
+│  │  ┌──────────────┐ ┌──────────────┐                                  │   │
+│  │  │  Pipeline    │ │  CopyJob     │                                  │   │
+│  │  │ Tool (flag)  │ │ Tool (flag)  │                                  │   │
+│  │  └──────────────┘ └──────────────┘                                  │   │
 │  └─────────────────────────────────────────────────────────────────────┘   │
 │                                    │                                        │
 │  ┌─────────────────────────────────────────────────────────────────────┐   │
@@ -74,6 +78,10 @@ The Microsoft Data Factory MCP Server is a .NET-based application that implement
 │  │  │ ArrowData    │ │DataTransform │ │DataflowDef   │ │GatewayClus-│  │   │
 │  │  │ReaderService │ │   Service    │ │  Processor   │ │terDatasrc  │  │   │
 │  │  └──────────────┘ └──────────────┘ └──────────────┘ └────────────┘  │   │
+│  │  ┌──────────────┐ ┌──────────────┐                                  │   │
+│  │  │FabricPipeline│ │FabricCopyJob │                                  │   │
+│  │  │   Service    │ │   Service    │                                  │   │
+│  │  └──────────────┘ └──────────────┘                                  │   │
 │  └─────────────────────────────────────────────────────────────────────┘   │
 │                                    │                                        │
 │  ┌─────────────────────────────────────────────────────────────────────┐   │
@@ -102,7 +110,9 @@ The Microsoft Data Factory MCP Server is a .NET-based application that implement
 │  │  │ IFabricWorkspaceSvc│  │  │  │Response Ext  │ │MQuery Ext    │   │    │
 │  │  │ IFabricDataflowSvc │  │  │  │Json Ext      │ │HttpResponse  │   │    │
 │  │  │ IFabricCapacitySvc │  │  │  └──────────────┘ └──────────────┘   │    │
-│  │  │ IValidationService │  │  └──────────────────────────────────────┘    │                                              │
+│  │  │ IFabricPipelineSvc │  │  └──────────────────────────────────────┘    │                                              │
+│  │  │ IFabricCopyJobSvc  │  │                                              │
+│  │  │ IValidationService │  │                                              │
 │  │  │ IArrowDataReader   │  │                                              │
 │  │  │ IDataTransformSvc  │  │                                              │
 │  │  │ IDataflowDefProc   │  │                                              │
@@ -123,6 +133,8 @@ The Microsoft Data Factory MCP Server is a .NET-based application that implement
 │                       │  • Workspaces         │                              │
 │                       │  • Dataflows          │                              │
 │                       │  • Capacities         │                              │
+│                       │  • Pipelines          │                              │
+│                       │  • Copy Jobs          │                              │
 │                       └─────────────────────┘                               │
 │  ┌─────────────────────────────────────────────────────────────────────┐   │
 │  │                    Power BI API (v2.0)                               │   │
@@ -247,6 +259,30 @@ MCP Tools are the public interface that AI assistants interact with. Each tool i
 
 #### CapacityTool
 - `ListCapacitiesAsync()`: List Fabric capacities user has access to
+
+#### PipelineTool (Feature Flag: `--pipeline`)
+- `ListPipelinesAsync()`: List pipelines in a workspace with optional pagination
+- `CreatePipelineAsync()`: Create a new pipeline
+- `GetPipelineAsync()`: Get pipeline metadata by ID
+- `UpdatePipelineAsync()`: Update pipeline metadata (displayName, description)
+- `GetPipelineDefinitionAsync()`: Get pipeline definition with decoded base64 content
+- `UpdatePipelineDefinitionAsync()`: Update pipeline definition with JSON content
+- `RunPipelineAsync()`: Run a pipeline on demand
+- `GetPipelineRunStatusAsync()`: Get status of a pipeline run by job instance ID
+- `CreatePipelineScheduleAsync()`: Create a schedule for a pipeline
+- `ListPipelineSchedulesAsync()`: List schedules configured for a pipeline
+
+#### CopyJobTool (Feature Flag: `--copy-job`)
+- `ListCopyJobsAsync()`: List copy jobs in a workspace with optional pagination
+- `CreateCopyJobAsync()`: Create a new copy job
+- `GetCopyJobAsync()`: Get copy job metadata by ID
+- `UpdateCopyJobAsync()`: Update copy job metadata (displayName, description)
+- `GetCopyJobDefinitionAsync()`: Get copy job definition with decoded base64 content
+- `UpdateCopyJobDefinitionAsync()`: Update copy job definition with JSON content
+- `RunCopyJobAsync()`: Run a copy job on demand
+- `GetCopyJobRunStatusAsync()`: Get status of a copy job run by job instance ID
+- `CreateCopyJobScheduleAsync()`: Create a schedule for a copy job
+- `ListCopyJobSchedulesAsync()`: List schedules configured for a copy job
 
 ### 2a. MCP App Resources Layer
 
@@ -673,6 +709,8 @@ Named HTTP client constants:
 #### FeatureFlags
 Feature flag constants for conditional tool registration:
 - `DataflowQuery`: Enable/disable DataflowQueryTool (`--dataflow-query`)
+- `Pipeline`: Enable/disable PipelineTool (`--pipeline`)
+- `CopyJob`: Enable/disable CopyJobTool (`--copy-job`)
 
 #### FeatureFlagRegistration
 Extension methods for registering tools based on feature flags:

--- a/docs/copyjob-management.md
+++ b/docs/copyjob-management.md
@@ -1,0 +1,509 @@
+# Copy Job Management Guide
+
+This guide covers how to use the Microsoft Data Factory MCP Server for managing Microsoft Fabric copy jobs.
+
+## Overview
+
+The copy job management tools allow you to:
+- **List** all copy jobs within a specific workspace
+- **Create** new copy jobs in Microsoft Fabric workspaces
+- **Get** copy job metadata by ID
+- **Update** copy job metadata (display name and description)
+- **Get** copy job definitions with decoded base64 content
+- **Update** copy job definitions with JSON content
+- **Run** copy jobs on demand (with optional execution data)
+- **Check** copy job run status by job instance ID
+- **Create** copy job schedules (Cron, Daily, Weekly, Monthly)
+- **List** schedules configured for a copy job
+- Navigate paginated results for large copy job collections
+
+## MCP Tools
+
+### list_copy_jobs
+
+Returns a list of Copy Jobs from the specified workspace. This API supports pagination.
+
+#### Usage
+```
+list_copy_jobs(workspaceId: "12345678-1234-1234-1234-123456789012")
+```
+
+#### With Pagination
+```
+list_copy_jobs(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  continuationToken: "next-page-token"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID to list copy jobs from |
+| `continuationToken` | No | A token for retrieving the next page of results |
+
+#### Response Format
+```json
+{
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "copyJobCount": 3,
+  "continuationToken": "eyJza2lwIjoyMCwidGFrZSI6MjB9",
+  "continuationUri": "https://api.fabric.microsoft.com/v1/workspaces/12345/copyJobs?continuationToken=abc123",
+  "hasMoreResults": true,
+  "copyJobs": [
+    {
+      "id": "87654321-4321-4321-4321-210987654321",
+      "displayName": "Sales Data Copy Job",
+      "description": "Copies daily sales data between lakehouses",
+      "type": "CopyJob",
+      "workspaceId": "12345678-1234-1234-1234-123456789012",
+      "folderId": "11111111-1111-1111-1111-111111111111"
+    }
+  ]
+}
+```
+
+### create_copy_job
+
+Creates a Copy Job in the specified workspace.
+
+#### Usage
+```
+create_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  displayName: "My New Copy Job"
+)
+```
+
+#### With Optional Parameters
+```
+create_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  displayName: "Sales Data Copy Job",
+  description: "Copies daily sales data between lakehouses",
+  folderId: "11111111-1111-1111-1111-111111111111"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID where the copy job will be created |
+| `displayName` | Yes | The Copy Job display name |
+| `description` | No | The Copy Job description (max 256 characters) |
+| `folderId` | No | The folder ID where the copy job will be created (defaults to workspace root) |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Copy job 'Sales Data Copy Job' created successfully",
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "displayName": "Sales Data Copy Job",
+  "description": "Copies daily sales data between lakehouses",
+  "type": "CopyJob",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "folderId": "11111111-1111-1111-1111-111111111111",
+  "createdAt": "2026-02-12T10:30:00Z"
+}
+```
+
+### get_copy_job
+
+Gets the metadata of a Copy Job by ID.
+
+#### Usage
+```
+get_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to retrieve |
+
+#### Response Format
+```json
+{
+  "id": "87654321-4321-4321-4321-210987654321",
+  "displayName": "Sales Data Copy Job",
+  "description": "Copies daily sales data between lakehouses",
+  "type": "CopyJob",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "folderId": "11111111-1111-1111-1111-111111111111"
+}
+```
+
+### update_copy_job
+
+Updates the metadata (displayName and/or description) of a Copy Job.
+
+#### Usage
+```
+update_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  displayName: "Updated Copy Job Name"
+)
+```
+
+#### With Both Fields
+```
+update_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  displayName: "Renamed Copy Job",
+  description: "Updated description for the copy job"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to update |
+| `displayName` | No* | The new display name |
+| `description` | No* | The new description |
+
+*At least one of `displayName` or `description` must be provided.
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Copy job 'Renamed Copy Job' updated successfully",
+  "copyJob": {
+    "id": "87654321-4321-4321-4321-210987654321",
+    "displayName": "Renamed Copy Job",
+    "description": "Updated description for the copy job",
+    "type": "CopyJob",
+    "workspaceId": "12345678-1234-1234-1234-123456789012",
+    "folderId": "11111111-1111-1111-1111-111111111111"
+  }
+}
+```
+
+### get_copy_job_definition
+
+Gets the definition of a Copy Job. The definition contains the copy job JSON configuration with base64-encoded parts, which are automatically decoded for readability.
+
+#### Usage
+```
+get_copy_job_definition(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to get the definition for |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "partsCount": 1,
+  "parts": [
+    {
+      "path": "copyjob-content.json",
+      "payloadType": "InlineBase64",
+      "decodedPayload": "{\"source\":{\"type\":\"Lakehouse\"},\"destination\":{\"type\":\"Lakehouse\"}}"
+    }
+  ]
+}
+```
+
+### update_copy_job_definition
+
+Updates the definition of a Copy Job with the provided JSON content. The JSON will be base64-encoded and sent to the API.
+
+#### Usage
+```
+update_copy_job_definition(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  definitionJson: "{\"source\":{\"type\":\"Lakehouse\"},\"destination\":{\"type\":\"Lakehouse\"}}"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to update |
+| `definitionJson` | Yes | The copy job definition JSON content (must be valid JSON) |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "message": "Copy job definition updated successfully"
+}
+```
+
+### run_copy_job
+
+Runs a Copy Job on demand. Returns a job instance ID that can be used to track the run status.
+
+#### Usage
+```
+run_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321"
+)
+```
+
+#### With Optional Execution Data
+```
+run_copy_job(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  executionDataJson: "{\"parameters\":{\"loadDate\":\"2026-02-24\"}}"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to run |
+| `executionDataJson` | No | Optional execution data as JSON string |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Copy job run triggered successfully",
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "jobInstanceId": "34147f60-c8f1-4bb7-8b7e-24557a6bfeed",
+  "locationUrl": "https://api.fabric.microsoft.com/v1/workspaces/.../jobs/instances/34147f60-c8f1-4bb7-8b7e-24557a6bfeed",
+  "hint": "Use get_copy_job_run_status with the jobInstanceId to check the run status"
+}
+```
+
+### get_copy_job_run_status
+
+Gets the status of a copy job run (job instance).
+
+#### Usage
+```
+get_copy_job_run_status(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  jobInstanceId: "34147f60-c8f1-4bb7-8b7e-24557a6bfeed"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID |
+| `jobInstanceId` | Yes | The job instance ID returned by `run_copy_job` |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "jobInstanceId": "34147f60-c8f1-4bb7-8b7e-24557a6bfeed",
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "jobType": "CopyJob",
+  "invokeType": "Manual",
+  "status": "Completed",
+  "startTimeUtc": "2026-02-24T08:15:00Z",
+  "endTimeUtc": "2026-02-24T08:16:32Z",
+  "failureReason": null
+}
+```
+
+Possible `status` values include: `NotStarted`, `InProgress`, `Completed`, `Failed`, `Cancelled`, `Deduped`.
+
+### create_copy_job_schedule
+
+Creates a schedule for a copy job.
+
+#### Usage
+```
+create_copy_job_schedule(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  enabled: true,
+  configurationJson: "{\"type\":\"Cron\",\"startDateTime\":\"2026-02-24T00:00:00\",\"endDateTime\":\"2026-03-24T23:59:59\",\"localTimeZoneId\":\"UTC\",\"interval\":30}"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to schedule |
+| `enabled` | Yes | Whether the schedule is enabled |
+| `configurationJson` | Yes | Schedule configuration as JSON |
+
+#### Supported Schedule Types
+
+- `Cron` (interval-based)
+- `Daily`
+- `Weekly`
+- `Monthly`
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Copy job schedule created successfully",
+  "scheduleId": "f36bc1bb-7007-4c15-b175-f63101609f95",
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "enabled": true,
+  "createdDateTime": "2026-02-24T08:20:11Z",
+  "configuration": {
+    "type": "Cron",
+    "interval": 30
+  },
+  "owner": {
+    "id": "owner-id"
+  }
+}
+```
+
+### list_copy_job_schedules
+
+Lists all schedules configured for a copy job. This API supports pagination.
+
+#### Usage
+```
+list_copy_job_schedules(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321"
+)
+```
+
+#### With Pagination
+```
+list_copy_job_schedules(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  copyJobId: "87654321-4321-4321-4321-210987654321",
+  continuationToken: "next-page-token"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the copy job |
+| `copyJobId` | Yes | The copy job ID to list schedules for |
+| `continuationToken` | No | A token for retrieving the next page of results |
+
+#### Response Format
+```json
+{
+  "copyJobId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "scheduleCount": 2,
+  "continuationToken": null,
+  "continuationUri": null,
+  "hasMoreResults": false,
+  "schedules": [
+    {
+      "id": "f36bc1bb-7007-4c15-b175-f63101609f95",
+      "enabled": true,
+      "createdDateTime": "2026-02-24T08:20:11Z",
+      "configuration": {
+        "type": "Cron",
+        "interval": 30
+      },
+      "owner": {
+        "id": "owner-id"
+      }
+    }
+  ]
+}
+```
+
+## Copy Job Properties
+
+Copy jobs in Microsoft Fabric include several key properties:
+
+### Basic Properties
+- **id**: Unique identifier for the copy job
+- **displayName**: Human-readable name of the copy job
+- **description**: Optional description of the copy job's purpose
+- **type**: Always "CopyJob" for copy job items
+- **workspaceId**: ID of the containing workspace
+
+### Optional Properties
+- **folderId**: ID of the folder containing the copy job (if organized in folders)
+
+## Usage Examples
+
+### Copy Job Creation
+```
+# Create a basic copy job
+> create a copy job named "Customer Data Copy" in workspace 12345678-1234-1234-1234-123456789012
+
+# Create copy job with description
+> create copy job "Sales Copy Job" with description "Daily sales data copy between lakehouses" in workspace 12345678-1234-1234-1234-123456789012
+
+# Create copy job in a specific folder
+> create copy job "Marketing Data Copy" in folder 11111111-1111-1111-1111-111111111111 within workspace 12345678-1234-1234-1234-123456789012
+```
+
+### Basic Copy Job Operations
+```
+# List all copy jobs in a workspace
+> list copy jobs in workspace 12345678-1234-1234-1234-123456789012
+
+# Get copy job details
+> show me copy job 87654321-4321-4321-4321-210987654321 in workspace 12345678-1234-1234-1234-123456789012
+
+# Update copy job name
+> rename copy job 87654321-4321-4321-4321-210987654321 to "New Copy Job Name"
+```
+
+### Copy Job Definition Operations
+```
+# Get copy job definition
+> show me the definition of copy job 87654321-4321-4321-4321-210987654321 in workspace 12345678-1234-1234-1234-123456789012
+
+# Update copy job definition
+> update the definition of copy job 87654321-4321-4321-4321-210987654321 with the following JSON configuration
+```
+
+### Copy Job Run and Schedule Operations
+```
+# Trigger a copy job run
+> run copy job 87654321-4321-4321-4321-210987654321 in workspace 12345678-1234-1234-1234-123456789012
+
+# Check copy job run status
+> get run status for copy job 87654321-4321-4321-4321-210987654321 with job instance 34147f60-c8f1-4bb7-8b7e-24557a6bfeed
+
+# Create a copy job schedule
+> create a daily schedule for copy job 87654321-4321-4321-4321-210987654321 in workspace 12345678-1234-1234-1234-123456789012
+
+# List copy job schedules
+> list schedules for copy job 87654321-4321-4321-4321-210987654321 in workspace 12345678-1234-1234-1234-123456789012
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Comprehensive documentation for the Microsoft Data Factory MCP Server.
 - **[Workspace Management Guide](workspace-management.md)** - Managing Microsoft Fabric workspaces
 - **[Dataflow Management Guide](dataflow-management.md)** - Managing Microsoft Fabric dataflows
 - **[Pipeline Management Guide](pipeline-management.md)** - Managing Microsoft Fabric pipelines
+- **[Copy Job Management Guide](copyjob-management.md)** - Managing Microsoft Fabric copy jobs
 
 ## Technical Documentation
 


### PR DESCRIPTION
- Add CopyJob models (CopyJob, CreateCopyJobRequest/Response, UpdateCopyJobRequest, ListCopyJobsResponse)
- Add CopyJob definition models (CopyJobDefinition, CopyJobDefinitionPart, GetCopyJobDefinitionResponse, UpdateCopyJobDefinitionRequest)
- Add IFabricCopyJobService interface with 10 operations
- Add FabricCopyJobService implementation using /copyJobs endpoints
- Add CopyJobExtensions for formatted output
- Add CopyJobTool with 10 MCP tool methods: List, Create, Get, GetDefinition, Update, UpdateDefinition, Run, GetRunStatus, CreateSchedule, ListSchedules
- Register CopyJob in DI (ServiceCollectionExtensions, FeatureFlags, McpTestFixture)
- Add CopyJobToolIntegrationTests with 45 test cases (38 unauthenticated + 7 authenticated)

# Manual validation

Copy job tools.
<img width="589" height="264" alt="image" src="https://github.com/user-attachments/assets/1486658e-c8d6-4b0f-b046-472b9f3d860f" />

List copy jobs.
<img width="615" height="267" alt="image" src="https://github.com/user-attachments/assets/69b5ebf0-7b6c-4ab9-8a7f-74086b852e3f" />

Get the definition.
<img width="604" height="372" alt="image" src="https://github.com/user-attachments/assets/bf0c1bf3-b3b6-4ba1-8230-8d7e955d7f4d" />


Run and monitor status.
<img width="599" height="581" alt="image" src="https://github.com/user-attachments/assets/b898a67c-e9e2-444a-a4b3-a5f0751934fc" />
