### PR TITLE
Fix credential scanner CSCAN-GENERAL0030 in eval file

### DIFF
--- a/evals/connections.eval.md
+++ b/evals/connections.eval.md
@@ -70,7 +70,7 @@ Tools under test:
 **Difficulty:** Medium
 
 **User prompt:**
-> Create a new SQL connection called "Prod SQL" to server `sql.contoso.com` database `SalesDB` using basic auth with username `admin` and password `p@ss`
+> Create a new SQL connection called "Prod SQL" to server `sql.contoso.com` database `SalesDB` using basic auth with username `sqladmin` and password `<PLACEHOLDER>`
 
 **Expected tool call(s):**
 - Tool: `CreateConnectionAsync`
@@ -78,7 +78,7 @@ Tools under test:
   - `connectionType`: `SQL`
   - `connectionParameters`: `{"server":"sql.contoso.com","database":"SalesDB"}`
   - `credentialType`: `Basic`
-  - `credentials`: `{"username":"admin","password":"p@ss"}`
+  - `credentials`: `{"username":"sqladmin","password":"<PLACEHOLDER>"}`
 
 **Assertions:**
 - Must use programmatic create, not UI tool


### PR DESCRIPTION
## Problem
The publish pipeline is failing due to credential scanner rule CSCAN-GENERAL0030 ("Found User Login Credentials") flagging fake username/password values in `evals/connections.eval.md` at line 81.

## Fix
Replaced the fake login credentials in EVAL-CONN-004 with obviously placeholder values:
- `admin` → `sqladmin`
- `p@ss` → `<PLACEHOLDER>`

These are eval test case examples (not real credentials), but the pattern triggered the scanner.