### PR TITLE
Add custom Copilot agents and skills

### DIFF
--- a/.github/agents/builder.agent.md
+++ b/.github/agents/builder.agent.md
@@ -1,0 +1,14 @@
+---
+description: "Use when: building projects, running builds, checking build errors, verifying compilation."
+name: "Builder"
+model: "Claude Opus 4.6 (copilot)"
+tools: [execute, read, memory, todo]
+user-invocable: true
+argument-hint: "Specify what to build: the full solution, a specific project, or tests"
+---
+
+You run builds and report results. You do NOT modify source code.
+
+Load the `builder.datafactory` skill for build commands and troubleshooting.
+
+Always run from repo root: `Q:\Repos\DataFactory.MCP`

--- a/.github/agents/builder.agent.md
+++ b/.github/agents/builder.agent.md
@@ -11,4 +11,4 @@ You run builds and report results. You do NOT modify source code.
 
 Load the `builder.datafactory` skill for build commands and troubleshooting.
 
-Always run from repo root: `Q:\Repos\DataFactory.MCP`
+Always run from the repo root.

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -1,0 +1,23 @@
+---
+description: "Use when: writing code, fixing bugs, implementing features, refactoring, adding MCP tools. Writes code following repo patterns."
+name: "Coder"
+model: "Claude Opus 4.6 (copilot)"
+tools: [vscode, execute, read, agent, edit, search, web, memory, todo]
+user-invocable: true
+argument-hint: "Describe the code change, bug fix, or feature to implement"
+---
+
+Load the `datafactory.architecture` skill first to understand project structure.
+Load the `coder.datafactory-style` skill for C# coding conventions.
+For new MCP tools, load the `architecture.mcp-tools` skill.
+For building, delegate to the **Builder** agent or load the `builder.datafactory` skill.
+
+When working with external libraries or APIs, verify documentation via web search. Your training data may be stale.
+
+## Mandatory Principles
+
+1. **SRP** — Tools handle MCP protocol; Services handle Fabric API calls
+2. **OCP** — New capabilities = new classes, not modifications to existing ones
+3. **DIP** — Depend on interfaces (`Abstractions/`), not concrete types
+4. **Error handling** — Check auth state before API calls; translate API errors to meaningful MCP responses
+5. **Nullable safety** — Nullable is enabled project-wide; respect it

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -1,0 +1,24 @@
+---
+name: orchestrator
+description: "Coordinates multi-step coding tasks (Planner→Coder→Builder→Tester→Reviewer). Use for ANY task requiring coordination."
+model: "Claude Opus 4.6 (copilot)"
+tools: [read, agent, execute, memory, todo]
+agents: [Planner, Coder, Tester, Reviewer, Builder]
+argument-hint: "Describe the complex task to break down and delegate"
+---
+
+You are a project orchestrator. You break down complex requests into tasks and delegate to specialist subagents. You coordinate work but NEVER implement anything yourself.
+
+## Pipeline
+
+1. **Plan** (Planner) — Research codebase, create plan. Skip for trivial changes.
+2. **Implement** (Coder) — Execute the plan.
+3. **Build** (Builder) — Run `dotnet build`. Never skip.
+4. **Test** (Tester) — Write/run tests. Skip for docs-only changes.
+5. **Review** (Reviewer) — Review final changes. Report issues to Coder if critical.
+
+## Rules
+
+- **Loop on failure** — Builder/Tester errors go back to Coder (max 3 loops)
+- **Never skip Build**
+- **Parallelize when safe** — independent Planner research can run in parallel

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,0 +1,20 @@
+---
+description: "Use when: creating implementation plans, researching codebase before coding, identifying edge cases, planning features or bug fixes."
+name: "Planner"
+model: "Claude Opus 4.6 (copilot)"
+tools: [vscode, execute, read, agent, edit, search, web, memory, todo]
+user-invocable: true
+argument-hint: "Describe the feature or issue to plan for"
+---
+
+You create plans. You do NOT write code.
+
+Load the `datafactory.architecture` skill first to understand the project structure and patterns.
+For new MCP tool work, also load the `architecture.mcp-tools` skill.
+
+## Workflow
+
+1. **Research** — Explore codebase, find similar implementations to follow
+2. **Verify contracts** — Check interfaces in `Abstractions/` and models in `Models/`
+3. **Consider edge cases** — Auth states, null responses, API errors
+4. **Plan** — Structured plan with specific file paths and changes

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,22 @@
+---
+description: "Use when: reviewing code changes, checking quality, verifying patterns compliance, or identifying issues."
+name: "Reviewer"
+model: "Claude Opus 4.6 (copilot)"
+tools: [read, search, memory, todo]
+user-invocable: true
+argument-hint: "Describe the code or files to review"
+---
+
+You analyze code but NEVER modify it. You produce actionable review feedback.
+
+Load the `datafactory.architecture` skill to understand project structure and patterns.
+Load the `coder.datafactory-style` skill for coding conventions.
+
+## Review Focus
+
+1. **Architecture** — Tools handle MCP; Services handle API; Models are pure data
+2. **Correctness** — Null safety, error handling, auth checks, edge cases
+3. **Security** — No secrets, tokens not logged, input sanitized
+4. **Testability** — Dependencies injectable, error paths covered
+
+Only report issues that genuinely matter. Output: severity, file/line, issue, fix.

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -1,0 +1,14 @@
+---
+description: "Use when: writing unit tests, adding test coverage, fixing failing tests, or verifying behavior. Follows xUnit patterns."
+name: "Tester"
+model: "Claude Opus 4.6 (copilot)"
+tools: [read, edit, search, execute, todo, memory]
+user-invocable: true
+argument-hint: "Describe what code needs tests or which tests need fixing"
+---
+
+You write and fix tests. You do NOT implement production code.
+
+Load the `tester.testing-patterns` skill for xUnit patterns and conventions.
+Load the `datafactory.architecture` skill to understand project structure.
+For building tests, load the `builder.datafactory` skill.

--- a/.github/skills/architecture.mcp-tools/SKILL.md
+++ b/.github/skills/architecture.mcp-tools/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: architecture.mcp-tools
+description: "Patterns for adding new MCP tools, services, and models to DataFactory.MCP. Use when adding new Fabric API integrations or MCP capabilities."
+---
+
+# Adding MCP Tools — Patterns
+
+For the full architecture, see [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md).
+
+## Overview
+
+Every new MCP capability follows the **Tool → Service → Model** pattern:
+
+```
+1. Define Models       (DataFactory.MCP.Core/Models/)
+2. Define Interface    (DataFactory.MCP.Core/Abstractions/)
+3. Implement Service   (DataFactory.MCP.Core/Services/)
+4. Implement Tool      (DataFactory.MCP.Core/Tools/)
+5. Register in DI      (DataFactory.MCP.Core/Extensions/)
+6. Add Tests           (DataFactory.MCP.Tests/)
+```
+
+## Step-by-Step
+
+### 1. Models — Define data shapes
+
+Create request/response DTOs in `Models/`. Keep them as pure data containers — no business logic.
+
+### 2. Interface — Define the service contract
+
+Add to `Abstractions/`. The interface defines what operations are available.
+
+### 3. Service — Implement Fabric API calls
+
+Create in `Services/`. Follow existing services as examples:
+- `FabricGatewayService.cs` — Gateway CRUD operations
+- `FabricConnectionService.cs` — Connection management
+- `FabricDataflowService.cs` — Dataflow operations
+
+Key patterns:
+- Inject `HttpClient` (configured with auth handler)
+- Use `AuthenticationService` for token management
+- Return strongly-typed models
+- Handle HTTP errors gracefully
+
+### 4. Tool — Implement MCP interface
+
+Create in `Tools/`. Follow existing tools as examples:
+- `GatewayTool.cs` — Simple CRUD tools
+- `ConnectionsTool.cs` — Tools with UI resources
+- `Dataflow/` — Complex multi-tool directory
+
+Key patterns:
+- Define tool name, description, and JSON schema for parameters
+- Validate inputs before calling service
+- Format responses for MCP protocol
+- Handle auth-not-ready state
+
+### 5. DI Registration
+
+Register new services and tools in `Extensions/` so they're available at runtime.
+
+### 6. Tests
+
+Add xUnit tests in `DataFactory.MCP.Tests/`:
+- Test parameter validation
+- Test service response parsing
+- Test error handling paths
+
+## Existing Tools Reference
+
+| Tool File | Service | Capability |
+|-----------|---------|-----------|
+| `AuthenticationTool.cs` | `AuthenticationService` | Azure AD auth flows |
+| `GatewayTool.cs` | `FabricGatewayService` | Gateway CRUD |
+| `ConnectionsTool.cs` | `FabricConnectionService` | Connection management |
+| `WorkspacesTool.cs` | `FabricWorkspaceService` | Workspace listing |
+| `CapacityTool.cs` | `FabricCapacityService` | Capacity management |
+| `Dataflow/` | `FabricDataflowService` | Dataflow operations |
+| `Pipeline/` | `FabricPipelineService` | Pipeline management |
+| `CopyJob/` | `FabricCopyJobService` | Copy job management |
+| `CreateConnectionUITool.cs` | `FabricConnectionService` | UI wizard for connections |
+
+## Feature Flags
+
+Some tools are gated behind feature flags (e.g., Pipeline, CopyJob, DataflowQuery). Check `Configuration/` for how feature flags control tool registration.

--- a/.github/skills/builder.datafactory/SKILL.md
+++ b/.github/skills/builder.datafactory/SKILL.md
@@ -12,7 +12,7 @@ description: "Building, testing, and running the DataFactory.MCP project. Use wh
 
 ## Commands
 
-All commands run from repo root: `Q:\Repos\DataFactory.MCP`
+All commands run from the repo root.
 
 | Task | Command |
 |------|---------|

--- a/.github/skills/builder.datafactory/SKILL.md
+++ b/.github/skills/builder.datafactory/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: builder.datafactory
+description: "Building, testing, and running the DataFactory.MCP project. Use when building source, running tests, or troubleshooting build errors."
+---
+
+# Building DataFactory.MCP
+
+## Prerequisites
+
+- .NET 10 SDK installed
+- NuGet feeds configured (see `nuget.config` and `nuget.private.config`)
+
+## Commands
+
+All commands run from repo root: `Q:\Repos\DataFactory.MCP`
+
+| Task | Command |
+|------|---------|
+| Build all | `dotnet build` |
+| Build release | `dotnet build -c Release` |
+| Build specific project | `dotnet build DataFactory.MCP.Core/` |
+| Run all tests | `dotnet test` |
+| Run tests verbose | `dotnet test -v normal` |
+| Run specific test | `dotnet test --filter "FullyQualifiedName~TestName"` |
+| Run with coverage | `dotnet test --collect:"XPlat Code Coverage"` |
+| Run MCP server | `dotnet run --project DataFactory.MCP` |
+| Clean + build | `dotnet clean && dotnet build` |
+| Restore packages | `dotnet restore` |
+
+## Versioning
+
+Version is defined in `Directory.Build.props`:
+```xml
+<MajorVersion>0</MajorVersion>
+<MinorVersion>19</MinorVersion>
+<PatchVersion>0</PatchVersion>
+<PreReleaseLabel>beta</PreReleaseLabel>
+```
+
+To bump version, use `Update-ServerVersion.ps1` or edit `Directory.Build.props` directly.
+
+## NuGet Packages Produced
+
+- `Microsoft.DataFactory.MCP` — Main server package
+- `Microsoft.DataFactory.MCP.Core` — Core library
+- `Microsoft.DataFactory.MCP.Http` — HTTP transport
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Missing packages | `dotnet restore` (check `nuget.config` for feed URLs) |
+| Framework not found | Install .NET 10 SDK |
+| Private feed auth | Check `nuget.private.config` credentials |
+| Build warnings | Nullable is enabled project-wide; fix nullable warnings |

--- a/.github/skills/coder.datafactory-style/SKILL.md
+++ b/.github/skills/coder.datafactory-style/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: coder.datafactory-style
+description: "C# coding standards and conventions for DataFactory.MCP. Use when writing or reviewing C# code."
+---
+
+# Coding Style — DataFactory.MCP
+
+## Project Settings
+
+- **Target:** net10.0
+- **Nullable:** enabled (project-wide)
+- **Implicit usings:** enabled
+- **License:** MIT
+
+## Conventions
+
+### Naming
+
+| Element | Style | Example |
+|---------|-------|---------|
+| Classes | PascalCase | `FabricGatewayService` |
+| Interfaces | `I` prefix | `IFabricGatewayService` |
+| Methods | PascalCase | `ListGatewaysAsync` |
+| Parameters | camelCase | `gatewayClusterId` |
+| Private fields | `_` prefix | `_httpClient` |
+| Constants | PascalCase | `MaxRetryCount` |
+| Async methods | `Async` suffix | `GetGatewayAsync` |
+
+### File Organization
+
+- One primary class per file
+- File name matches class name
+- Tools in `Tools/`, Services in `Services/`, Models in `Models/`
+- Interfaces in `Abstractions/`
+
+### Null Safety
+
+- Nullable is ON — respect nullable annotations
+- Use `?` for nullable types, `!` only when provably non-null
+- Prefer pattern matching: `if (value is not null)`
+- Never suppress `#pragma warning disable` for nullable without justification
+
+### Error Handling
+
+- Catch specific exceptions, not `Exception` broadly
+- Translate API errors to meaningful MCP error responses
+- Always check auth state before API calls
+- Log errors with context (operation name, resource ID)
+
+### Async/Await
+
+- All I/O operations must be async
+- Use `ConfigureAwait(false)` in library code (Core project)
+- Never use `.Result` or `.Wait()` — always await
+
+### Dependency Injection
+
+- All services registered in DI container via extension methods in `Extensions/`
+- Constructor injection only
+- Depend on interfaces (`Abstractions/`), not concrete types
+
+## Key Patterns
+
+### Tool → Service → Model
+
+```
+Tool (MCP schema + validation) → Service (API call) → Model (data)
+```
+
+- Tools handle: parameter parsing, validation, MCP response formatting
+- Services handle: HTTP calls, auth tokens, error translation
+- Models handle: data shape (DTOs, no logic)
+
+### Configuration
+
+- Feature flags control tool availability
+- API versions managed in `Configuration/` classes
+- Environment variables for auth settings

--- a/.github/skills/datafactory.architecture/SKILL.md
+++ b/.github/skills/datafactory.architecture/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: datafactory.architecture
+description: "DataFactory.MCP project architecture, component layers, design patterns, and extension points. Use when working on any code in this repo."
+---
+
+# DataFactory.MCP Architecture
+
+For the full architecture reference, see [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md).
+
+## Project Structure
+
+```
+DataFactory.MCP/             — Main MCP server (stdio transport, entry point)
+DataFactory.MCP.Core/        — Core library (all business logic)
+  ├── Abstractions/          — Interfaces and contracts
+  ├── Configuration/         — App configuration classes
+  ├── Extensions/            — Extension methods and DI registration
+  ├── Infrastructure/        — Cross-cutting concerns (HTTP, logging)
+  ├── Models/                — Data models and DTOs
+  ├── Parsing/               — Input parsing utilities
+  ├── Resources/             — Embedded resources
+  ├── Services/              — Fabric API service clients
+  ├── Tools/                 — MCP tool implementations
+  └── Validation/            — Input validation
+DataFactory.MCP.Http/        — HTTP transport layer (AspNetCore)
+DataFactory.MCP.Tests/       — Test suite (xUnit)
+DataFactory.WindowsMCP/      — Windows-specific MCP implementation
+claude-skills/               — Claude skill definitions (RAG pattern)
+docs/                        — Feature documentation
+evals/                       — Evaluation test scenarios
+```
+
+## Layered Architecture
+
+```
+AI Chat Interface (VS Code, Visual Studio)
+        │ MCP Protocol (JSON-RPC over stdio)
+        ▼
+┌─ MCP Tools Layer ──────────────────────────────┐
+│  AuthenticationTool, GatewayTool,               │
+│  ConnectionsTool, WorkspacesTool,               │
+│  Dataflow/*, Pipeline/*, CopyJob/*,             │
+│  CapacityTool, CreateConnectionUITool           │
+├─ Core Services Layer ──────────────────────────┤
+│  AuthenticationService, FabricGatewayService,   │
+│  FabricConnectionService, FabricWorkspaceService│
+│  FabricDataflowService, FabricPipelineService,  │
+│  FabricCopyJobService, FabricCapacityService,   │
+│  ValidationService, DataTransformationService   │
+├─ Infrastructure Layer ─────────────────────────┤
+│  AuthenticatedHttpHandler, ApiVersionConfig,    │
+│  McpSessionAccessor, BackgroundTasks            │
+├─ Abstractions Layer ───────────────────────────┤
+│  Interfaces for all services                    │
+├─ Models Layer ─────────────────────────────────┤
+│  DTOs, request/response types, enums            │
+└─────────────────────────────────────────────────┘
+        │ Fabric REST APIs (with Azure AD tokens)
+        ▼
+    Microsoft Fabric / Power BI Service
+```
+
+## Key Design Principles
+
+- **Separation of Concerns**: Tools handle MCP protocol; Services handle Fabric API calls
+- **Dependency Injection**: All services registered via DI with proper lifetimes
+- **Async-First**: All I/O operations use async/await
+- **Configuration-Driven**: Feature flags control tool availability
+- **Extensibility**: New tools/services can be added without modifying existing code
+
+## Feature Documentation
+
+| Topic | Doc |
+|-------|-----|
+| Authentication | [`docs/authentication.md`](../../../docs/authentication.md) |
+| Gateways | [`docs/gateway-management.md`](../../../docs/gateway-management.md) |
+| Connections | [`docs/connection-management.md`](../../../docs/connection-management.md) |
+| Dataflows | [`docs/dataflow-management.md`](../../../docs/dataflow-management.md) |
+| Pipelines | [`docs/pipeline-management.md`](../../../docs/pipeline-management.md) |
+| Copy Jobs | [`docs/copyjob-management.md`](../../../docs/copyjob-management.md) |
+| Workspaces | [`docs/workspace-management.md`](../../../docs/workspace-management.md) |
+| Capacities | [`docs/capacity-management.md`](../../../docs/capacity-management.md) |
+| Full architecture | [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md) |
+
+## Domain Knowledge
+
+For Data Factory / M language / Dataflow patterns, see `claude-skills/`:
+- `datafactory-core.md` — M basics, MCP tools, connection discovery
+- `datafactory-destinations.md` — Output destinations, DataDestination patterns
+- `datafactory-performance.md` — Query tuning, chunking, query folding
+- `datafactory-advanced.md` — Fast Copy, Action.Sequence, Modern Evaluator

--- a/.github/skills/tester.testing-patterns/SKILL.md
+++ b/.github/skills/tester.testing-patterns/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: tester.testing-patterns
+description: "xUnit testing patterns and conventions for DataFactory.MCP. Use when writing tests, fixing test failures, or adding test coverage."
+---
+
+# Testing in DataFactory.MCP
+
+## Test Stack
+
+- **Framework:** xUnit (`[Fact]`, `[Theory]`, `[InlineData]`)
+- **Runner:** `xunit.runner.visualstudio`
+- **Skippable:** `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If(...)`)
+- **Coverage:** coverlet
+- **Target:** net10.0
+
+## Test Location
+
+All tests live in `DataFactory.MCP.Tests/`.
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Run all | `dotnet test` |
+| Verbose | `dotnet test -v normal` |
+| Filter | `dotnet test --filter "FullyQualifiedName~TestName"` |
+| Coverage | `dotnet test --collect:"XPlat Code Coverage"` |
+
+## Naming Convention
+
+```
+MethodName_Scenario_ExpectedResult
+```
+
+Examples:
+- `Authenticate_WithValidCredentials_ReturnsToken`
+- `ListGateways_WhenNotAuthenticated_ThrowsException`
+- `CreateConnection_WithInvalidType_ReturnsError`
+
+## Test Patterns
+
+### Unit Test (Arrange-Act-Assert)
+
+```csharp
+public class MyServiceTests
+{
+    [Fact]
+    public void MethodName_Scenario_ExpectedResult()
+    {
+        // Arrange
+        var service = new MyService();
+
+        // Act
+        var result = service.DoSomething();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("expected", result.Value);
+    }
+}
+```
+
+### Parameterized Tests
+
+```csharp
+[Theory]
+[InlineData("input1", "expected1")]
+[InlineData("input2", "expected2")]
+public void MethodName_WithVariousInputs_ReturnsExpected(string input, string expected)
+{
+    var result = MyService.Process(input);
+    Assert.Equal(expected, result);
+}
+```
+
+### Skippable Tests (for environment-dependent tests)
+
+```csharp
+[SkippableFact]
+public void IntegrationTest_RequiresAuth()
+{
+    Skip.If(string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")),
+        "Requires Azure credentials");
+    // test body
+}
+```
+
+## What to Test
+
+- **Tools:** Parameter validation, response formatting, error handling
+- **Services:** API call construction, response parsing, error translation
+- **Models:** Serialization/deserialization roundtrips
+- **Edge cases:** Null inputs, empty collections, unauthenticated state, API errors
+
+## Evaluation Scenarios
+
+Reference `evals/` for integration test scenarios:
+- `authentication.eval.md`, `connections.eval.md`, `dataflows.eval.md`
+- `gateways.eval.md`, `pipelines.eval.md`, `multi-step.eval.md`

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,36 @@
+# DataFactory.MCP — Copilot Agent
+
+## Your Role
+
+You are a **triage-dispatch agent**. Understand the user's request and delegate to the appropriate agent.
+
+**You do not write code or make direct file changes.** All code changes go through the `orchestrator` agent.
+
+## Dispatch
+
+| Request type | Dispatch to |
+|-------------|-------------|
+| Any code change (features, bugs, refactoring, new tools) | `orchestrator` |
+| Build or test issues | `Builder` |
+| Code review | `Reviewer` |
+
+## Available Agents
+
+| Agent | Role |
+|-------|------|
+| `orchestrator` | Coordinates Planner → Coder → Builder → Tester → Reviewer |
+| `Planner` | Researches codebase and creates implementation plans |
+| `Coder` | Writes code following repo patterns |
+| `Builder` | Builds projects, runs tests, reports errors |
+| `Tester` | Writes and fixes xUnit tests |
+| `Reviewer` | Reviews code for quality and correctness |
+
+## Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `datafactory.architecture` | Project structure, layers, design patterns, doc index |
+| `builder.datafactory` | Build/test/run commands, troubleshooting |
+| `tester.testing-patterns` | xUnit patterns, test conventions |
+| `coder.datafactory-style` | C# coding standards for this repo |
+| `architecture.mcp-tools` | How to add new MCP tools (Tool → Service → Model) |


### PR DESCRIPTION
## Context

Add custom Copilot agent definitions and skills for the DataFactory.MCP repo.

### Agents (lightweight — role + skill references)

| Agent | Role |
|-------|------|
| orchestrator | Coordinates Planner -> Coder -> Builder -> Tester -> Reviewer |
| planner | Researches codebase and creates implementation plans |
| coder | Writes code following repo patterns |
| builder | Builds projects, runs tests, reports errors |
| tester | Writes and fixes xUnit tests |
| reviewer | Reviews code for quality and correctness |

### Skills (domain knowledge)

| Skill | Purpose |
|-------|---------|
| datafactory.architecture | Project structure, layers, design patterns, doc index |
| builder.datafactory | Build/test/run commands, troubleshooting |
| tester.testing-patterns | xUnit conventions, test patterns |
| coder.datafactory-style | C# coding standards for this repo |
| architecture.mcp-tools | How to add new MCP tools (Tool -> Service -> Model) |

### Design Decisions

- **Agents are thin** — just role description + which skills to load. All detailed knowledge lives in skills.
- **Skills reference existing docs** — docs/ARCHITECTURE.md and docs/*.md for deep content, avoiding duplication.
- **Naming convention** — skills use the pattern agent-prefix.domain (e.g. builder.datafactory, coder.datafactory-style).
