### PR TITLE
Update ModelContextProtocol to 1.1.0 and add central package management

### DIFF
--- a/DataFactory.MCP.Core/DataFactory.MCP.Core.csproj
+++ b/DataFactory.MCP.Core/DataFactory.MCP.Core.csproj
@@ -27,11 +27,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.67.0" />
-        <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
-        <PackageReference Include="Apache.Arrow" Version="22.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Identity.Client" />
+        <PackageReference Include="ModelContextProtocol" />
+        <PackageReference Include="Apache.Arrow" />
     </ItemGroup>
 
 </Project>

--- a/DataFactory.MCP.Http/DataFactory.MCP.Http.csproj
+++ b/DataFactory.MCP.Http/DataFactory.MCP.Http.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.6.0-preview.1" />
+        <PackageReference Include="ModelContextProtocol.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DataFactory.MCP.Tests/DataFactory.MCP.Tests.csproj
+++ b/DataFactory.MCP.Tests/DataFactory.MCP.Tests.csproj
@@ -9,23 +9,23 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.76.0" />
-        <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
-        <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Identity.Client" />
+        <PackageReference Include="ModelContextProtocol" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+        <PackageReference Include="Xunit.SkippableFact" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DataFactory.WindowsMCP/DataFactory.WindowsMCP.csproj
+++ b/DataFactory.WindowsMCP/DataFactory.WindowsMCP.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Office.Interop.Excel" Version="16.0.18925.20022" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.Office.Interop.Excel" GeneratePathProperty="true" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Apache.Arrow" Version="22.1.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.76.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.Office.Interop.Excel" Version="16.0.18925.20022" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Changes

- **Upgrade ModelContextProtocol SDK** from `0.6.0-preview.1` to `1.1.0` (stable release)
- **Add NuGet Central Package Management** via `Directory.Packages.props`
  - All package versions centralized in one file
  - Version attributes removed from all `.csproj` files
  - Packages sorted alphabetically for readability
- **Align Microsoft.Identity.Client** to `4.76.0` across projects

## Verification
- Build: 0 errors, 0 warnings
- Tests: 105 passed, 0 failed