### PR TITLE
Security hardening for HTTP deployment endpoint

### DIFF
--- a/.github/workflows/deploy-http.yml
+++ b/.github/workflows/deploy-http.yml
@@ -111,7 +111,7 @@ jobs:
         uses: azure/appservice-settings@v1
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          app-settings-json: '[{"name": "device-code-auth", "value": "${{ github.event.inputs.device_code_auth || true }}"}, {"name": "interactive-auth", "value": "${{ github.event.inputs.interactive_auth || false }}"}]'
+          app-settings-json: '[{"name": "device-code-auth", "value": "${{ github.event.inputs.device_code_auth || true }}"}, {"name": "interactive-auth", "value": "${{ github.event.inputs.interactive_auth || false }}"}, {"name": "Logging__LogLevel__Default", "value": "Warning"}]'
 
       - name: "Deploy to Azure Web App"
         id: deploy

--- a/DataFactory.MCP.Core/Abstractions/FabricServiceBase.cs
+++ b/DataFactory.MCP.Core/Abstractions/FabricServiceBase.cs
@@ -62,7 +62,7 @@ public abstract class FabricServiceBase
         Logger.LogInformation("Posting to: {Url}", url);
 
         var jsonContent = JsonSerializer.Serialize(request, JsonOptions);
-        Logger.LogInformation("Request body: {Body}", jsonContent);
+        Logger.LogDebug("Request body: {Body}", jsonContent);
         var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
 
         var response = await HttpClient.PostAsync(url, content);

--- a/DataFactory.MCP.Core/Services/AuthenticationStateManager.cs
+++ b/DataFactory.MCP.Core/Services/AuthenticationStateManager.cs
@@ -9,6 +9,10 @@ namespace DataFactory.MCP.Services;
 /// <summary>
 /// Manages authentication state, tokens, and provides access token operations
 /// </summary>
+/// <remarks>
+/// This service is registered as singleton and shares authentication state across all requests.
+/// For HTTP deployments, ensure the endpoint is protected by external authentication.
+/// </remarks>
 public class AuthenticationStateManager : IAuthenticationStateManager
 {
     private readonly ILogger<AuthenticationStateManager> _logger;

--- a/DataFactory.MCP.Core/Tools/AuthenticationTool.cs
+++ b/DataFactory.MCP.Core/Tools/AuthenticationTool.cs
@@ -74,6 +74,10 @@ public class AuthenticationTool
         }
     }
 
+    /// <remarks>
+    /// SECURITY: This tool returns the raw access token. In HTTP deployments, ensure the endpoint
+    /// is protected by authentication to prevent unauthorized token access.
+    /// </remarks>
     [McpServerTool, Description(@"Get current access token for authenticated user")]
     public async Task<string> GetAccessTokenAsync()
     {

--- a/DataFactory.MCP.Http/Program.cs
+++ b/DataFactory.MCP.Http/Program.cs
@@ -42,6 +42,8 @@ mcpBuilder.AddDataFactoryMcpOptionalTools(
 var app = builder.Build();
 
 // Map MCP endpoints
+// SECURITY: This endpoint requires external authentication (e.g., Azure Easy Auth, API Management).
+// Do not expose this endpoint to untrusted networks without authentication.
 app.MapMcp();
 
 // Add a simple health check endpoint


### PR DESCRIPTION
## Summary

Security hardening changes addressing findings from a ScanWorld security analysis report.

## Changes

- **FabricServiceBase.cs**: Changed request body logging from \LogInformation\ to \LogDebug\ to prevent plaintext credential leakage (passwords, keys, tokens, service principal secrets) in production logs
- **deploy-http.yml**: Added \Logging__LogLevel__Default: Warning\ to App Service settings as a safe production default
- **AuthenticationStateManager.cs**: Added XML doc security remarks about singleton shared state in HTTP deployments
- **AuthenticationTool.cs**: Added XML doc security remarks on \GetAccessTokenAsync\ about raw token exposure
- **Program.cs**: Added security warning comments documenting that external authentication is required for HTTP deployments

## Notes

1. Most of the concerns and comments are on the HTTP version which is not deployed anywhere yet
2. Some of the concerns like the \GetAccessToken\ tool — it will never be accessible without initial login, same as watching HTTP traffic in a browser
