### PR TITLE
feat(skills): decompose monolithic skill into fabricskills-standard 

### DIFF
--- a/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DataFactory.MCP.Abstractions.Interfaces.DMTSv2;
 using DataFactory.MCP.Configuration;
 using DataFactory.MCP.Infrastructure.Http;
 using DataFactory.MCP.Resources.McpApps;
+using DataFactory.MCP.Resources.Skills;
 using DataFactory.MCP.Services;
 using DataFactory.MCP.Services.Authentication;
 using DataFactory.MCP.Services.BackgroundTasks;
@@ -101,7 +102,8 @@ public static class ServiceCollectionExtensions
             .WithTools<PipelineTool>()
             .WithTools<CopyJobTool>()
             .WithTools<CreateConnectionUITool>()                // MCP Apps: Create Connection UI
-            .WithResources<CreateConnectionResourceHandler>();  // MCP Apps: Create Connection Resource
+            .WithResources<CreateConnectionResourceHandler>()  // MCP Apps: Create Connection Resource
+            .WithResources<SkillResourceHandler>();             // SEP-2640: Skill Resources
     }
 
     /// <summary>

--- a/DataFactory.MCP.Core/Resources/Skills/SkillRegistry.cs
+++ b/DataFactory.MCP.Core/Resources/Skills/SkillRegistry.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+
+namespace DataFactory.MCP.Resources.Skills;
+
+/// <summary>
+/// Registry of skill files loaded at startup. Provides the skill index
+/// and individual file content for the SEP-2640 skill:// resource handler.
+/// Skills are loaded from the skills/ directory relative to the application root.
+/// </summary>
+public static class SkillRegistry
+{
+    private static readonly Dictionary<string, SkillEntry> _skills = new(StringComparer.OrdinalIgnoreCase);
+    private static bool _initialized;
+
+    /// <summary>
+    /// A registered skill with its metadata and file contents.
+    /// </summary>
+    public record SkillEntry(
+        string Name,
+        string Description,
+        Dictionary<string, string> Files // relative path → content
+    );
+
+    /// <summary>
+    /// Initialize the registry by scanning the skills/ directory.
+    /// Call once at startup. Safe to call multiple times (idempotent).
+    /// </summary>
+    public static void Initialize(string? basePath = null)
+    {
+        if (_initialized) return;
+
+        var root = basePath ?? AppContext.BaseDirectory;
+        var skillsDir = FindSkillsDirectory(root);
+        if (skillsDir == null)
+        {
+            _initialized = true;
+            return;
+        }
+
+        foreach (var skillDir in Directory.GetDirectories(skillsDir))
+        {
+            var skillMd = Path.Combine(skillDir, "SKILL.md");
+            if (!File.Exists(skillMd)) continue;
+
+            var skillName = Path.GetFileName(skillDir);
+            var content = File.ReadAllText(skillMd);
+            var description = ExtractDescription(content);
+
+            var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SKILL.md"] = content
+            };
+
+            // Load references/ subdirectory if present
+            var refsDir = Path.Combine(skillDir, "references");
+            if (Directory.Exists(refsDir))
+            {
+                foreach (var refFile in Directory.GetFiles(refsDir, "*.md"))
+                {
+                    var relPath = $"references/{Path.GetFileName(refFile)}";
+                    files[relPath] = File.ReadAllText(refFile);
+                }
+            }
+
+            _skills[skillName] = new SkillEntry(skillName, description, files);
+        }
+
+        // Also load common/ files as a pseudo-skill
+        var commonDir = Path.Combine(Path.GetDirectoryName(skillsDir)!, "common");
+        if (Directory.Exists(commonDir))
+        {
+            var commonFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var commonFile in Directory.GetFiles(commonDir, "*.md"))
+            {
+                commonFiles[Path.GetFileName(commonFile)] = File.ReadAllText(commonFile);
+            }
+            if (commonFiles.Count > 0)
+            {
+                _skills["_common"] = new SkillEntry(
+                    "_common",
+                    "Shared reference documents for Data Factory MCP skills (authentication, connections, patterns).",
+                    commonFiles);
+            }
+        }
+
+        _initialized = true;
+    }
+
+    /// <summary>
+    /// Returns the skill index as a JSON array of {name, description} objects.
+    /// </summary>
+    public static string GetIndex()
+    {
+        var index = _skills.Values
+            .Where(s => !s.Name.StartsWith("_")) // exclude pseudo-skills from index
+            .Select(s => new { name = s.Name, description = s.Description })
+            .OrderBy(s => s.name);
+        return JsonSerializer.Serialize(index, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>
+    /// Returns the content of a specific file within a skill.
+    /// </summary>
+    public static string GetFile(string skillName, string filePath)
+    {
+        if (!_skills.TryGetValue(skillName, out var skill))
+            throw new ArgumentException($"Unknown skill: {skillName}");
+        if (!skill.Files.TryGetValue(filePath, out var content))
+            throw new ArgumentException($"File not found in skill '{skillName}': {filePath}");
+        return content;
+    }
+
+    /// <summary>
+    /// Returns all registered skill names.
+    /// </summary>
+    public static IEnumerable<string> GetSkillNames() => _skills.Keys.Where(k => !k.StartsWith("_"));
+
+    /// <summary>
+    /// Returns true if a skill with the given name exists.
+    /// </summary>
+    public static bool HasSkill(string skillName) => _skills.ContainsKey(skillName);
+
+    /// <summary>
+    /// Lists all files available in a skill.
+    /// </summary>
+    public static IEnumerable<string> GetSkillFiles(string skillName)
+    {
+        if (!_skills.TryGetValue(skillName, out var skill))
+            throw new ArgumentException($"Unknown skill: {skillName}");
+        return skill.Files.Keys;
+    }
+
+    /// <summary>
+    /// Extract the description field from YAML frontmatter.
+    /// </summary>
+    private static string ExtractDescription(string content)
+    {
+        if (!content.StartsWith("---")) return string.Empty;
+
+        var endIndex = content.IndexOf("---", 3);
+        if (endIndex < 0) return string.Empty;
+
+        var frontmatter = content[3..endIndex];
+        var descStart = frontmatter.IndexOf("description:", StringComparison.OrdinalIgnoreCase);
+        if (descStart < 0) return string.Empty;
+
+        // Handle multi-line YAML description (> folded scalar)
+        var afterKey = frontmatter[(descStart + "description:".Length)..];
+        var lines = afterKey.Split('\n');
+
+        var descLines = new List<string>();
+        var started = false;
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (!started)
+            {
+                if (trimmed == ">" || trimmed == "|") { started = true; continue; }
+                if (!string.IsNullOrEmpty(trimmed)) { descLines.Add(trimmed); break; } // single-line
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(trimmed) || (!line.StartsWith("  ") && !line.StartsWith("\t")))
+                    break; // end of indented block
+                descLines.Add(trimmed);
+            }
+        }
+
+        return string.Join(" ", descLines);
+    }
+
+    /// <summary>
+    /// Find the skills/ directory by walking up from the base path.
+    /// </summary>
+    private static string? FindSkillsDirectory(string basePath)
+    {
+        var current = basePath;
+        for (var i = 0; i < 5; i++) // walk up max 5 levels
+        {
+            var candidate = Path.Combine(current, "skills");
+            if (Directory.Exists(candidate) &&
+                Directory.GetFiles(candidate, "SKILL.md", SearchOption.AllDirectories).Length > 0)
+                return candidate;
+
+            var parent = Directory.GetParent(current);
+            if (parent == null) break;
+            current = parent.FullName;
+        }
+        return null;
+    }
+}

--- a/DataFactory.MCP.Core/Resources/Skills/SkillResourceHandler.cs
+++ b/DataFactory.MCP.Core/Resources/Skills/SkillResourceHandler.cs
@@ -1,0 +1,63 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace DataFactory.MCP.Resources.Skills;
+
+/// <summary>
+/// MCP Resource handler for SEP-2640 skill:// URI scheme.
+/// Exposes Data Factory skills as MCP Resources for progressive discovery:
+///   - skill://index.json → list all skills with name + description
+///   - skill://{skillName}/SKILL.md → full skill instructions
+///   - skill://{skillName}/references/{file}.md → supplementary reference
+///   - skill://_common/{file}.md → shared reference documents
+/// </summary>
+[McpServerResourceType]
+public class SkillResourceHandler
+{
+    /// <summary>
+    /// Discovery index — returns JSON array of {name, description} for all registered skills.
+    /// Clients read this first to decide which skill to load (~100 tokens per entry).
+    /// </summary>
+    [McpServerResource(
+        UriTemplate = "skill://index.json",
+        Name = "Skill Index",
+        MimeType = "application/json")]
+    [Description("List all available Data Factory skills with name and description for routing decisions")]
+    public static ReadResourceResult GetIndex()
+    {
+        var index = SkillRegistry.GetIndex();
+        return new ReadResourceResult
+        {
+            Contents = [new TextResourceContents
+            {
+                Uri = "skill://index.json",
+                Text = index,
+                MimeType = "application/json"
+            }]
+        };
+    }
+
+    /// <summary>
+    /// Individual skill file access — returns a specific markdown file from a skill.
+    /// Use for loading full skill instructions or supplementary references on demand.
+    /// </summary>
+    [McpServerResource(
+        UriTemplate = "skill://{skillName}/{filePath}",
+        Name = "Skill Content",
+        MimeType = "text/markdown")]
+    [Description("Read a specific skill file by skill name and relative file path")]
+    public static ReadResourceResult GetSkillFile(string skillName, string filePath)
+    {
+        var content = SkillRegistry.GetFile(skillName, filePath);
+        return new ReadResourceResult
+        {
+            Contents = [new TextResourceContents
+            {
+                Uri = $"skill://{skillName}/{filePath}",
+                Text = content,
+                MimeType = "text/markdown"
+            }]
+        };
+    }
+}

--- a/DataFactory.MCP.Http/Program.cs
+++ b/DataFactory.MCP.Http/Program.cs
@@ -39,6 +39,9 @@ mcpBuilder.AddDataFactoryMcpOptionalTools(
     args,
     logger);
 
+// Initialize skill registry for SEP-2640 skill:// resources
+DataFactory.MCP.Resources.Skills.SkillRegistry.Initialize();
+
 var app = builder.Build();
 
 // Map MCP endpoints

--- a/DataFactory.MCP/Program.cs
+++ b/DataFactory.MCP/Program.cs
@@ -40,4 +40,7 @@ mcpBuilder.AddDataFactoryMcpOptionalTools(
     args.Concat(["--interactive-auth"]).ToArray(),  // Enable interactive auth by default for stdio
     logger);
 
+// Initialize skill registry for SEP-2640 skill:// resources
+DataFactory.MCP.Resources.Skills.SkillRegistry.Initialize();
+
 await builder.Build().RunAsync();

--- a/DataFactory.WindowsMCP/Program.cs
+++ b/DataFactory.WindowsMCP/Program.cs
@@ -37,4 +37,7 @@ mcpBuilder.AddDataFactoryMcpOptionalTools(
     args.Concat(["--interactive-auth"]).ToArray(),  // Enable interactive auth by default for stdio
     logger);
 
+// Initialize skill registry for SEP-2640 skill:// resources
+DataFactory.MCP.Resources.Skills.SkillRegistry.Initialize();
+
 await builder.Build().RunAsync();

--- a/agents/DataFactoryEngineer.agent.md
+++ b/agents/DataFactoryEngineer.agent.md
@@ -1,0 +1,95 @@
+---
+name: DataFactoryEngineer
+description: >
+  Orchestrate Microsoft Fabric Data Factory workflows across dataflows, pipelines, copy jobs,
+  and connections using MCP tools. Routes user requests to the correct item-specific skill
+  based on intent signals. Handles disambiguation between overlapping item types (e.g.,
+  "copy data" → Copy Job vs Dataflow) and cross-item diagnostics.
+delegates_to:
+  - dataflows-authoring-mcp
+  - dataflows-consumption-mcp
+  - pipelines-authoring-mcp
+  - pipelines-consumption-mcp
+  - copyjobs-authoring-mcp
+  - copyjobs-consumption-mcp
+  - connections-authoring-mcp
+  - datafactory-operations-mcp
+---
+
+# DataFactoryEngineer Agent
+
+Orchestrates Data Factory MCP operations by routing to the correct item-specific skill.
+
+## Delegation Rules
+
+### By User Intent
+
+| Intent Signal | Route To | Why |
+|---|---|---|
+| "copy data", "move data", "replicate", "sync", no transforms | `copyjobs-authoring-mcp` | Copy Jobs are the simple source→dest path |
+| "transform", "M query", "join", "aggregate", "ETL", "Power Query" | `dataflows-authoring-mcp` | Dataflows handle M-based transformations |
+| "orchestrate", "chain activities", "schedule multiple", "pipeline" | `pipelines-authoring-mcp` | Pipelines orchestrate multiple activities |
+| "connect to", "credentials", "gateway", "connection error" | `connections-authoring-mcp` | Connection lifecycle management |
+| "failed", "error", "troubleshoot", "why did it fail", "diagnose" | `datafactory-operations-mcp` | Cross-item operational triage |
+| "list", "inspect", "what exists", "show me", "browse", "status" | Consumption variant of the relevant item type | Read-only discovery and monitoring |
+
+### Disambiguation: Copy Job vs Dataflow
+
+This is the most common routing ambiguity. Decision rule:
+
+```text
+User wants to move data from A to B
+    │
+    ├── Any transforms mentioned? (filter, join, aggregate, custom logic)
+    │     ├── Yes → dataflows-authoring-mcp
+    │     └── No  → copyjobs-authoring-mcp
+    │
+    ├── User says "dataflow" or "M query" explicitly?
+    │     └── Yes → dataflows-authoring-mcp
+    │
+    ├── User says "copy job" explicitly?
+    │     └── Yes → copyjobs-authoring-mcp
+    │
+    └── Ambiguous? Default → copyjobs-authoring-mcp (simpler path)
+        Ask: "Do you need to transform the data, or is this a straight copy?"
+```
+
+### Disambiguation: Pipeline vs Direct Execution
+
+```text
+User wants to run something
+    │
+    ├── Single item (one dataflow or one copy job)?
+    │     └── Run it directly via the item's authoring skill
+    │
+    ├── Multiple items with dependencies?
+    │     └── pipelines-authoring-mcp (orchestrate with dependsOn)
+    │
+    └── Needs a schedule?
+          ├── Single item schedule → item's own schedule tool
+          └── Multi-item orchestrated schedule → pipelines-authoring-mcp
+```
+
+## Must / Prefer / Avoid
+
+### MUST
+- Route based on intent signals, not assumptions
+- Ask for clarification when ambiguous (copy vs transform)
+- Check authentication status before any operation
+
+### PREFER
+- Copy Jobs over Dataflows for simple data movement (less complexity)
+- Direct item execution over pipeline wrapper for single-item runs
+- Operations skill for any failure diagnosis before attempting fixes
+
+### AVOID
+- Defaulting to Dataflows for everything — Copy Jobs and Pipelines exist for a reason
+- Attempting to fix failures without first diagnosing via operations skill
+- Loading all skills at once — load the one matched by intent
+
+## Prerequisite
+
+All operations require authentication. Start every session with:
+```text
+DATAFACTORY-MCP-CORE.md → authenticate → list_workspaces → route to skill
+```

--- a/common/CONNECTIONS-CORE.md
+++ b/common/CONNECTIONS-CORE.md
@@ -1,0 +1,82 @@
+# Connections & Gateways — Core Reference
+
+Shared reference for connection model, gateway types, and binding lifecycle. Used by `connections-authoring-mcp` and referenced by dataflow/pipeline/copy job skills.
+
+## Connection Model
+
+A Fabric connection represents authenticated access to a data source.
+
+| Field | Description |
+|-------|-------------|
+| `connectionId` | Unique identifier |
+| `DatasourceId` | The GUID used for binding (plain format, not composite) |
+| `connectionType` | Source type: `SQL`, `Web`, `Lakehouse`, `Warehouse`, `AzureBlobs`, `Dataverse`, etc. |
+| `credentialType` | Auth method: `OAuth2`, `ServicePrincipal`, `Key`, `Anonymous`, `Windows` |
+| `gatewayId` | Gateway binding (null for cloud-only sources) |
+
+## Connection Type Mapping
+
+| User Says | `connectionType` | Match Field |
+|-----------|------------------|-------------|
+| SQL database, SQL Server | `SQL` | server + database in parameters |
+| SharePoint file, Excel on SharePoint | `Web` | URL containing `.sharepoint.com` |
+| Lakehouse | `Lakehouse` | workspace + lakehouse name |
+| Blob storage, Azure storage | `AzureBlobs` | account name |
+| Web API, REST endpoint | `Web` | base URL |
+| Warehouse | `Warehouse` | workspace + warehouse name |
+| Dataverse, Dynamics | `Dataverse` | environment URL |
+
+**Fabric-source connections** (Lakehouse, Warehouse, Eventhouse): artifact names are NOT globally unique — scoped to parent workspace. Always require workspace ID to disambiguate.
+
+## Binding Lifecycle
+
+Connections must be bound to items (dataflows) before queries can authenticate:
+
+```text
+1. add_connection_to_dataflow    → bind before save
+2. save_dataflow_definition      → save M document (MAY WIPE connections)
+3. add_connection_to_dataflow    → re-bind after save
+4. execute_query                 → validate binding works
+```
+
+**Critical:** `save_dataflow_definition` may wipe connection bindings. Always re-add after save. This is the #1 cause of credential errors.
+
+### Binding Operations
+
+| Intent | Parameters |
+|--------|-----------|
+| Add one connection | `connectionIds = "GUID"` |
+| Add multiple | `connectionIds = ["GUID1", "GUID2"]` |
+| Replace all | `connectionIds = "GUID"` + `clearExisting = true` |
+| Clear all | `clearExisting = true` (no connectionIds) |
+
+## Gateway Types
+
+| Type | Created Via | Purpose |
+|------|-----------|---------|
+| On-premises | Manual install (download agent) | Access on-prem sources behind firewall |
+| Personal | Manual install (single user) | Personal development gateway |
+| VNet | `create_virtualnetwork_gateway` API | Access Azure VNet-isolated resources |
+
+Only VNet gateways can be created programmatically.
+
+## Multi-Source Requirements
+
+When combining multiple source types (e.g., Lakehouse + SharePoint):
+
+1. **Every source needs its own connection bound** — separate `add_connection_to_dataflow` calls
+2. **M document needs `[AllowCombine = true]`** section attribute — otherwise privacy firewall blocks cross-source queries
+3. **Consolidated Lakehouse reads** — single `Lakehouse.Contents` call, not one per table
+4. **Fresh dataflow required** — never convert a published single-source to multi-source
+
+## Troubleshooting Matrix
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Credentials error after save | `save_dataflow_definition` wiped bindings | Re-add via `add_connection_to_dataflow` |
+| Credentials error, bindings look correct | Wrong GUID format (composite vs plain) | Use plain `DatasourceId` only |
+| Instant refresh fail (0-3s) on multi-source | Missing connection or `AllowCombine` | Bind all + add section attribute |
+| `list_connections` doesn't show known connection | User lacks permission | Check with workspace admin |
+| `create_connection` param errors | Wrong parameters for type | Call `list_supported_connection_types` first |
+| Connection timeout on-prem source | Missing/offline gateway | `list_gateways` → check status |
+| Stale connections after revert | `save_dataflow_definition` doesn't remove old bindings | Create new dataflow — no `remove_connection` tool |

--- a/common/DATAFACTORY-MCP-CORE.md
+++ b/common/DATAFACTORY-MCP-CORE.md
@@ -1,0 +1,79 @@
+# Data Factory MCP — Common Patterns
+
+Cross-cutting prerequisites for all Data Factory MCP skills. Read this before any item-specific skill.
+
+## Authentication
+
+The MCP server requires authentication before any operation. Three paths:
+
+| Tool | When |
+|------|------|
+| `authenticate_interactive` | User has a browser (Claude Desktop, claude.ai) |
+| `authenticate_device_code` | Headless/terminal — user copies a code to browser |
+| `authenticate_service_principal` | CI/CD, automation — no user interaction |
+
+**Always check first:** Call `get_authentication_status` before attempting auth. If already authenticated, skip.
+
+**Session lifecycle:**
+```text
+get_authentication_status → (if not authed) authenticate_* → list_workspaces → operate → logout
+```
+
+## Workspace Discovery
+
+`list_workspaces` returns all workspaces the authenticated user can access.
+
+**Pattern:** Every operation requires a `workspaceId`. Discover it first:
+```text
+list_workspaces → filter by name → extract workspaceId → use in subsequent calls
+```
+
+There is no `find_workspace` tool — always list and filter by name.
+
+## Capacity Discovery
+
+`list_capacities` returns available Fabric capacities with SKU, state, and region.
+
+**When to call:**
+- Before creating items — verify the target workspace has an active capacity
+- Troubleshooting "insufficient capacity" errors
+
+## MCP Tool Invocation Patterns
+
+### Error Handling
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 401 | Token expired or invalid | Re-authenticate |
+| 403 | Insufficient permissions | Check workspace role (need Contributor+) |
+| 429 | Rate limited | Wait and retry (exponential backoff) |
+| 404 | Item not found | Verify workspaceId + itemId |
+
+### Long-Running Operations
+
+Some operations (refresh, pipeline run) are async:
+1. Trigger: returns immediately with a job/run ID
+2. Poll: call status tool repeatedly until terminal state
+3. Terminal states: `Completed`, `Failed`, `Cancelled`
+
+### Common Mistake: GUID Formats
+
+- **Workspace/item IDs**: Plain GUIDs (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)
+- **Connection IDs for binding**: Plain `DatasourceId` GUID only — NOT the composite `{"ClusterId":"...","DatasourceId":"..."}` format from definitions
+
+## Must / Prefer / Avoid
+
+### MUST
+- Authenticate before any operation
+- Use `list_workspaces` to resolve workspace names to IDs
+- Check `get_authentication_status` before re-authenticating
+
+### PREFER
+- Interactive auth when user has a browser
+- Device code for headless environments
+- Service principal for automation
+
+### AVOID
+- Calling `authenticate_*` without checking status first
+- Assuming workspace names are unique — verify by listing
+- Hardcoding workspace or item IDs in reusable workflows

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,7 +23,9 @@ Cross-tool workflows live in `multi-step.eval.md`.
 | [connections.eval.md](connections.eval.md) | `ListSupportedConnectionTypesAsync`, `ListConnectionsAsync`, `GetConnectionAsync`, `CreateConnectionAsync`, `create_connection_ui` |
 | [gateways.eval.md](gateways.eval.md) | `ListGatewaysAsync`, `GetGatewayAsync`, `create_virtualnetwork_gateway` |
 | [dataflows.eval.md](dataflows.eval.md) | `ListDataflowsAsync`, `CreateDataflowAsync`, `AddConnectionToDataflowAsync`, `AddOrUpdateQueryInDataflowAsync`, `get_dataflow_definition`, `save_dataflow_definition`, `ExecuteQueryAsync`, `RefreshDataflowBackground`, `RefreshDataflowStatus` |
-| [pipelines.eval.md](pipelines.eval.md) | `ListPipelinesAsync`, `CreatePipelineAsync`, `GetPipelineAsync`, `GetPipelineDefinitionAsync`, `UpdatePipelineAsync`, `UpdatePipelineDefinitionAsync` |
+| [pipelines.eval.md](pipelines.eval.md) | `ListPipelinesAsync`, `CreatePipelineAsync`, `GetPipelineAsync`, `GetPipelineDefinitionAsync`, `UpdatePipelineAsync`, `UpdatePipelineDefinitionAsync`, `RunPipelineAsync`, `GetPipelineRunStatusAsync`, `CreatePipelineScheduleAsync`, `ListPipelineSchedulesAsync` |
+| [copyjobs.eval.md](copyjobs.eval.md) | `ListCopyJobsAsync`, `CreateCopyJobAsync`, `GetCopyJobAsync`, `GetCopyJobDefinitionAsync`, `UpdateCopyJobAsync`, `UpdateCopyJobDefinitionAsync`, `RunCopyJobAsync`, `GetCopyJobRunStatusAsync`, `CreateCopyJobScheduleAsync`, `ListCopyJobSchedulesAsync` |
+| [operations.eval.md](operations.eval.md) | Cross-item triage: `RefreshDataflowStatus`, `GetPipelineRunStatusAsync`, `GetCopyJobRunStatusAsync`, `AddConnectionToDataflowAsync`, `GetConnectionAsync` |
 | [multi-step.eval.md](multi-step.eval.md) | Cross-tool orchestration scenarios |
 
 ## Scenario Format
@@ -116,9 +118,11 @@ OPENAI_API_KEY=sk-... python evals/integration/run_integration_evals.py
 | Connections | 5 | 5 | 5 | 15 |
 | Gateways | 3 | 3 | 3 | 9 |
 | Dataflows | 9 | 7 | 6 | 22 |
-| Pipelines | 6 | 5 | 4 | 15 |
+| Pipelines | 9 | 7 | 7 | 23 |
+| Copy Jobs | 6 | 5 | 4 | 15 |
+| Operations (Cross-Item) | 4 | 2 | 2 | 8 |
 | Multi-step | — | — | — | 10 |
-| **Total** | **33** | **26** | **25** | **94** |
+| **Total** | **47** | **35** | **43** | **125** |
 
 ### Integration Evals (M Code Quality)
 
@@ -133,4 +137,4 @@ OPENAI_API_KEY=sk-... python evals/integration/run_integration_evals.py
 | Lifecycle | 2 |
 | **Total** | **20** |
 
-**Grand total: 114 evals** (94 tool-selection + 20 integration)
+**Grand total: 145 evals** (125 tool-selection + 20 integration)

--- a/evals/copyjobs.eval.md
+++ b/evals/copyjobs.eval.md
@@ -1,0 +1,323 @@
+# Copy Job Tool Evals
+
+Tools under test:
+- `ListCopyJobsAsync(workspaceId, continuationToken?)`
+- `CreateCopyJobAsync(workspaceId, displayName, description?)`
+- `GetCopyJobAsync(workspaceId, copyJobId)`
+- `GetCopyJobDefinitionAsync(workspaceId, copyJobId)`
+- `UpdateCopyJobAsync(workspaceId, copyJobId, displayName?, description?)`
+- `UpdateCopyJobDefinitionAsync(workspaceId, copyJobId, definitionJson)`
+- `RunCopyJobAsync(workspaceId, copyJobId)`
+- `GetCopyJobRunStatusAsync(workspaceId, copyJobId, runId)`
+- `CreateCopyJobScheduleAsync(workspaceId, copyJobId, scheduleConfig)`
+- `ListCopyJobSchedulesAsync(workspaceId, copyJobId)`
+
+---
+
+## Tool Selection
+
+### EVAL-CJ-001: List copy jobs
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Show me the copy jobs in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `ListCopyJobsAsync`
+  - `workspaceId`: `ws-data`
+
+**Assertions:**
+- Must select copy job list, not pipeline or dataflow list
+- "Copy jobs" is unambiguous
+
+---
+
+### EVAL-CJ-002: Create a copy job
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Create a new copy job called "Daily Sales Sync" in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `CreateCopyJobAsync`
+  - `workspaceId`: `ws-data`
+  - `displayName`: `Daily Sales Sync`
+
+**Assertions:**
+- Must use copy job create, not pipeline create
+- "Copy job" and "sync" are signals for data movement
+
+---
+
+### EVAL-CJ-003: Get copy job metadata
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Get details for copy job `cj-100` in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `GetCopyJobAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+
+**Assertions:**
+- "Details" maps to metadata, not definition
+
+---
+
+### EVAL-CJ-004: Get copy job definition
+
+**Category:** Tool Selection
+**Difficulty:** Medium
+
+**User prompt:**
+> Show me the configuration of copy job `cj-100` in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `GetCopyJobDefinitionAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+
+**Assertions:**
+- "Configuration" maps to definition (source/dest/mappings), not metadata
+- Must not call `GetCopyJobAsync` (that's metadata only)
+
+---
+
+### EVAL-CJ-005: Run a copy job
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Run copy job `cj-100` in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `RunCopyJobAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+
+**Assertions:**
+- "Run" is unambiguous for on-demand execution
+
+---
+
+### EVAL-CJ-006: Check copy job run status
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Check the status of copy job run `run-555` for copy job `cj-100` in workspace `ws-data`
+
+**Expected tool call(s):**
+- Tool: `GetCopyJobRunStatusAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+  - `runId`: `run-555`
+
+**Assertions:**
+- Must extract all three IDs
+
+---
+
+## Parameter Extraction
+
+### EVAL-CJ-007: Create with description
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Create a copy job called "Customer Replication" in workspace `ws-crm` with description "Replicates customer data from SQL Server to Lakehouse nightly"
+
+**Expected tool call(s):**
+- Tool: `CreateCopyJobAsync`
+  - `workspaceId`: `ws-crm`
+  - `displayName`: `Customer Replication`
+  - `description`: `Replicates customer data from SQL Server to Lakehouse nightly`
+
+**Assertions:**
+- All three parameters extracted correctly
+
+---
+
+### EVAL-CJ-008: Update copy job definition
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Update the definition of copy job `cj-200` in workspace `ws-data` with this config:
+> ```json
+> {"source": {"type": "SQL", "table": "dbo.Customers"}, "destination": {"type": "Lakehouse", "table": "customers_raw"}}
+> ```
+
+**Expected tool call(s):**
+- Tool: `UpdateCopyJobDefinitionAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-200`
+  - `definitionJson`: the complete JSON
+
+**Assertions:**
+- JSON passed verbatim
+- Must use definition update, not metadata update
+
+---
+
+### EVAL-CJ-009: Copy job ID from previous list
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Run the "Customer Replication" copy job
+
+**Context:**
+> Previous `ListCopyJobsAsync` returned:
+> ```json
+> { "workspaceId": "ws-crm", "copyJobs": [
+>   { "id": "cj-201", "displayName": "Customer Replication" },
+>   { "id": "cj-202", "displayName": "Product Sync" }
+> ]}
+> ```
+
+**Expected tool call(s):**
+- Tool: `RunCopyJobAsync`
+  - `workspaceId`: `ws-crm`
+  - `copyJobId`: `cj-201`
+
+**Assertions:**
+- Must resolve name to ID from context
+- Must infer workspace from prior list
+
+---
+
+### EVAL-CJ-010: Schedule a copy job
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Schedule copy job `cj-100` in workspace `ws-data` to run every day at midnight
+
+**Expected tool call(s):**
+- Tool: `CreateCopyJobScheduleAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+  - `scheduleConfig`: daily, 00:00
+
+**Assertions:**
+- "Every day at midnight" maps to daily schedule
+- Must use schedule creation, not run
+
+---
+
+### EVAL-CJ-011: List copy job schedules
+
+**Category:** Parameter Extraction
+**Difficulty:** Easy
+
+**User prompt:**
+> What schedules are set for copy job `cj-100` in workspace `ws-data`?
+
+**Expected tool call(s):**
+- Tool: `ListCopyJobSchedulesAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+
+**Assertions:**
+- Must select list schedules, not create schedule
+
+---
+
+## Edge Cases
+
+### EVAL-CJ-012: Copy job vs pipeline — "copy data"
+
+**Category:** Edge Case
+**Difficulty:** Hard
+
+**User prompt:**
+> I need to copy data from SQL Server to Lakehouse in workspace `ws-data`
+
+**Expected behavior:**
+- "Copy data" could map to Copy Job or a pipeline with Copy activity
+- Copy Job is the simpler, preferred path for direct source→dest movement
+- Model should suggest creating a Copy Job
+
+**Assertions:**
+- Should prefer Copy Job over pipeline for simple data movement
+- Must not create a Dataflow (no transforms mentioned)
+
+---
+
+### EVAL-CJ-013: Copy job run failed
+
+**Category:** Edge Case
+**Difficulty:** Medium
+
+**User prompt:**
+> My copy job run failed, what went wrong?
+
+**Context:**
+> Working with copy job `cj-100` in workspace `ws-data`, last run was `run-888`
+
+**Expected behavior:**
+- Call `GetCopyJobRunStatusAsync` to get error details
+- Present error information to user
+
+**Assertions:**
+- Must check run status first
+- Must not attempt to modify without diagnosing
+
+---
+
+### EVAL-CJ-014: Rename a copy job
+
+**Category:** Edge Case
+**Difficulty:** Easy
+
+**User prompt:**
+> Rename copy job `cj-100` in workspace `ws-data` to "Customer Sync v2"
+
+**Expected tool call(s):**
+- Tool: `UpdateCopyJobAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+  - `displayName`: `Customer Sync v2`
+
+**Assertions:**
+- "Rename" maps to metadata update, not definition update
+
+---
+
+### EVAL-CJ-015: Poll after run
+
+**Category:** Edge Case
+**Difficulty:** Medium
+
+**User prompt:**
+> Is my copy job done yet?
+
+**Context:**
+> Previous `RunCopyJobAsync` returned:
+> ```json
+> { "workspaceId": "ws-data", "copyJobId": "cj-100", "runId": "run-999" }
+> ```
+
+**Expected tool call(s):**
+- Tool: `GetCopyJobRunStatusAsync`
+  - `workspaceId`: `ws-data`
+  - `copyJobId`: `cj-100`
+  - `runId`: `run-999`
+
+**Assertions:**
+- Must extract all IDs from prior run context
+- Must not re-run the copy job

--- a/evals/operations.eval.md
+++ b/evals/operations.eval.md
@@ -1,0 +1,180 @@
+# Operations / Cross-Item Triage Evals
+
+Tests the model's ability to diagnose failures across Data Factory item types and route to the correct status/inspection tools.
+
+Tools referenced:
+- `RefreshDataflowStatus(workspaceId, dataflowId, jobInstanceId)`
+- `GetPipelineRunStatusAsync(workspaceId, pipelineId, runId)`
+- `GetCopyJobRunStatusAsync(workspaceId, copyJobId, runId)`
+- `AddConnectionToDataflowAsync(workspaceId, dataflowId, connectionIds?, clearExisting?)`
+- `ListConnectionsAsync(workspaceId?)`
+- `GetConnectionAsync(connectionId)`
+- `get_dataflow_definition(workspaceId, dataflowId)`
+
+---
+
+## Tool Selection
+
+### EVAL-OPS-001: Dataflow refresh failed — diagnose
+
+**Category:** Tool Selection
+**Difficulty:** Medium
+
+**User prompt:**
+> My dataflow refresh failed. The dataflow is `df-100` in workspace `ws-prod` and the job ID is `job-456`
+
+**Expected tool call(s):**
+- Tool: `RefreshDataflowStatus`
+  - `workspaceId`: `ws-prod`
+  - `dataflowId`: `df-100`
+  - `jobInstanceId`: `job-456`
+
+**Assertions:**
+- Must check dataflow refresh status, not pipeline status
+- Must extract all three IDs
+
+---
+
+### EVAL-OPS-002: Pipeline failed — drill into activity
+
+**Category:** Tool Selection
+**Difficulty:** Medium
+
+**User prompt:**
+> Pipeline `pl-200` in workspace `ws-prod` failed on run `run-abc`. The failed activity is a Dataflow activity. How do I find the root cause?
+
+**Expected behavior:**
+- Call `GetPipelineRunStatusAsync` to get activity-level details
+- Suggest checking `RefreshDataflowStatus` for the underlying dataflow error
+
+**Assertions:**
+- Must check pipeline run status first
+- Must advise looking at dataflow refresh status for root cause
+- Pipeline failure on a Dataflow activity → root cause is always in the dataflow
+
+---
+
+### EVAL-OPS-003: Credential error — re-bind connection
+
+**Category:** Tool Selection
+**Difficulty:** Medium
+
+**User prompt:**
+> I'm getting a credentials error when refreshing dataflow `df-100` in workspace `ws-prod`. The connection ID is `conn-xyz`.
+
+**Expected tool call(s):**
+- Tool: `AddConnectionToDataflowAsync`
+  - `workspaceId`: `ws-prod`
+  - `dataflowId`: `df-100`
+  - `connectionIds`: `conn-xyz`
+
+**Assertions:**
+- Credential errors after save → re-bind connection
+- Must use add connection tool, not create connection
+
+---
+
+### EVAL-OPS-004: DataflowNeverPublishedError
+
+**Category:** Tool Selection
+**Difficulty:** Hard
+
+**User prompt:**
+> I created a dataflow via MCP and tried to refresh it but got `DataflowNeverPublishedError`
+
+**Context:**
+> Dataflow `df-new` in workspace `ws-dev`
+
+**Expected behavior:**
+- Explain that API-created dataflows need `executeOption = "ApplyChangesIfNeeded"` on first refresh
+- Suggest calling `RefreshDataflowBackground` with `executeOption = "ApplyChangesIfNeeded"`
+
+**Assertions:**
+- Must identify the fix: `ApplyChangesIfNeeded`
+- Must not suggest deleting and recreating the dataflow
+
+---
+
+## Parameter Extraction
+
+### EVAL-OPS-005: Diagnose from vague error
+
+**Category:** Parameter Extraction
+**Difficulty:** Hard
+
+**User prompt:**
+> Something's wrong with my dataflow — it fails instantly, takes about 2 seconds
+
+**Context:**
+> Working with dataflow `df-multi` in workspace `ws-analytics`, last refresh job was `job-999`
+
+**Expected tool call(s):**
+- Tool: `RefreshDataflowStatus`
+  - `workspaceId`: `ws-analytics`
+  - `dataflowId`: `df-multi`
+  - `jobInstanceId`: `job-999`
+
+**Assertions:**
+- "Fails instantly" (0-3s) → likely privacy firewall or unpublished draft
+- Must check status before suggesting a fix
+- After seeing error, should suggest: AllowCombine (if multi-source) or ApplyChangesIfNeeded (if first refresh)
+
+---
+
+### EVAL-OPS-006: Connection health check
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Check if connection `conn-sql-01` is still working
+
+**Expected tool call(s):**
+- Tool: `GetConnectionAsync`
+  - `connectionId`: `conn-sql-01`
+
+**Assertions:**
+- Must inspect the connection details (credential type, gateway status)
+- Must not try to create or modify the connection
+
+---
+
+## Edge Cases
+
+### EVAL-OPS-007: Ambiguous failure — which item type?
+
+**Category:** Edge Case
+**Difficulty:** Hard
+
+**User prompt:**
+> Something in workspace `ws-prod` failed last night. I'm not sure if it was a dataflow, pipeline, or copy job.
+
+**Expected behavior:**
+- Need to discover which items exist and check their status
+- Suggest listing all three item types: `ListDataflowsAsync`, `ListPipelinesAsync`, `ListCopyJobsAsync`
+- Then check run/refresh status for each
+
+**Assertions:**
+- Must not guess the item type — discover first
+- Acceptable to call all three list tools in parallel
+
+---
+
+### EVAL-OPS-008: Scheduled job didn't run
+
+**Category:** Edge Case
+**Difficulty:** Medium
+
+**User prompt:**
+> My pipeline was supposed to run at 6am but it didn't execute
+
+**Context:**
+> Pipeline `pl-nightly` in workspace `ws-prod`
+
+**Expected behavior:**
+- Check if a schedule exists: `ListPipelineSchedulesAsync`
+- Check if a run was created: `GetPipelineRunStatusAsync` or list recent runs
+
+**Assertions:**
+- Must verify schedule exists before assuming it's a platform issue
+- "Didn't run" could be: no schedule configured, schedule paused, or run was Deduped

--- a/evals/pipelines.eval.md
+++ b/evals/pipelines.eval.md
@@ -7,6 +7,10 @@ Tools under test:
 - `GetPipelineDefinitionAsync(workspaceId, pipelineId)`
 - `UpdatePipelineAsync(workspaceId, pipelineId, displayName?, description?)`
 - `UpdatePipelineDefinitionAsync(workspaceId, pipelineId, definitionJson)`
+- `RunPipelineAsync(workspaceId, pipelineId)`
+- `GetPipelineRunStatusAsync(workspaceId, pipelineId, runId)`
+- `CreatePipelineScheduleAsync(workspaceId, pipelineId, scheduleConfig)`
+- `ListPipelineSchedulesAsync(workspaceId, pipelineId)`
 
 ---
 
@@ -328,3 +332,181 @@ Tools under test:
 - "Data pipeline" should map to Pipeline, not Dataflow
 - In Fabric terminology, "pipeline" specifically refers to the orchestration artifact
 - If unsure, calling both `ListPipelinesAsync` and `ListDataflowsAsync` is acceptable
+
+---
+
+## Pipeline Run & Schedule (PR #94+)
+
+### EVAL-PL-016: Run a pipeline on demand
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Run pipeline `pl-456` in workspace `ws-123`
+
+**Expected tool call(s):**
+- Tool: `RunPipelineAsync`
+  - `workspaceId`: `ws-123`
+  - `pipelineId`: `pl-456`
+
+**Assertions:**
+- Must select run tool, not update or create
+- "Run" is unambiguous for on-demand execution
+
+---
+
+### EVAL-PL-017: Check pipeline run status
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> Check the status of pipeline run `run-789` for pipeline `pl-456` in workspace `ws-123`
+
+**Expected tool call(s):**
+- Tool: `GetPipelineRunStatusAsync`
+  - `workspaceId`: `ws-123`
+  - `pipelineId`: `pl-456`
+  - `runId`: `run-789`
+
+**Assertions:**
+- Must select run status tool
+- Must extract all three IDs from prompt
+
+---
+
+### EVAL-PL-018: Schedule a pipeline
+
+**Category:** Tool Selection
+**Difficulty:** Medium
+
+**User prompt:**
+> Set up a daily schedule for pipeline `pl-456` in workspace `ws-123`
+
+**Expected tool call(s):**
+- Tool: `CreatePipelineScheduleAsync`
+  - `workspaceId`: `ws-123`
+  - `pipelineId`: `pl-456`
+  - `scheduleConfig`: contains daily frequency
+
+**Assertions:**
+- Must select schedule creation tool
+- "Daily schedule" maps to schedule, not run
+
+---
+
+### EVAL-PL-019: List pipeline schedules
+
+**Category:** Tool Selection
+**Difficulty:** Easy
+
+**User prompt:**
+> What schedules are configured for pipeline `pl-456` in workspace `ws-123`?
+
+**Expected tool call(s):**
+- Tool: `ListPipelineSchedulesAsync`
+  - `workspaceId`: `ws-123`
+  - `pipelineId`: `pl-456`
+
+**Assertions:**
+- "Schedules configured" maps to list schedules
+- Must not call run status
+
+---
+
+### EVAL-PL-020: Run then poll status
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Check if my pipeline run finished
+
+**Context:**
+> Previous `RunPipelineAsync` returned:
+> ```json
+> { "workspaceId": "ws-main", "pipelineId": "pl-001", "runId": "run-abc-123" }
+> ```
+
+**Expected tool call(s):**
+- Tool: `GetPipelineRunStatusAsync`
+  - `workspaceId`: `ws-main`
+  - `pipelineId`: `pl-001`
+  - `runId`: `run-abc-123`
+
+**Assertions:**
+- Must extract all three IDs from prior run context
+- Must not re-run the pipeline
+
+---
+
+### EVAL-PL-021: Run pipeline by name from list
+
+**Category:** Parameter Extraction
+**Difficulty:** Medium
+
+**User prompt:**
+> Run the "Nightly Sync" pipeline
+
+**Context:**
+> Previous `ListPipelinesAsync` returned:
+> ```json
+> { "workspaceId": "ws-main", "pipelines": [
+>   { "id": "pl-001", "displayName": "Nightly Sync" },
+>   { "id": "pl-002", "displayName": "Weekly Report" }
+> ]}
+> ```
+
+**Expected tool call(s):**
+- Tool: `RunPipelineAsync`
+  - `workspaceId`: `ws-main`
+  - `pipelineId`: `pl-001`
+
+**Assertions:**
+- Must resolve name to ID from context
+- Must infer workspace from prior list
+
+---
+
+### EVAL-PL-022: Schedule vs run disambiguation
+
+**Category:** Edge Case
+**Difficulty:** Hard
+
+**User prompt:**
+> I want this pipeline to run every Monday at 6am
+
+**Context:**
+> Working with pipeline `pl-456` in workspace `ws-123`
+
+**Expected tool call(s):**
+- Tool: `CreatePipelineScheduleAsync`
+  - `workspaceId`: `ws-123`
+  - `pipelineId`: `pl-456`
+  - `scheduleConfig`: weekly, Monday, 6:00 AM
+
+**Assertions:**
+- "Run every Monday" is a schedule request, not an on-demand run
+- Must use schedule creation, not run tool
+
+---
+
+### EVAL-PL-023: Pipeline failed — what happened?
+
+**Category:** Edge Case
+**Difficulty:** Hard
+
+**User prompt:**
+> My pipeline run failed, what went wrong?
+
+**Context:**
+> Working with pipeline `pl-456` in workspace `ws-123`, last run was `run-999`
+
+**Expected behavior:**
+- Call `GetPipelineRunStatusAsync` to get error details
+- If the failure is from a Dataflow activity, suggest checking `RefreshDataflowStatus`
+
+**Assertions:**
+- Must check run status first
+- Must not attempt to fix without diagnosing

--- a/evals/tools_schema.json
+++ b/evals/tools_schema.json
@@ -459,6 +459,231 @@
           "required": ["workspaceId", "pipelineId", "definitionJson"]
         }
       }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "RunPipelineAsync",
+        "description": "Runs a Pipeline on demand. Returns a job instance ID that can be used to track the run status with GetPipelineRunStatusAsync.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the pipeline (required)" },
+            "pipelineId": { "type": "string", "description": "The pipeline ID to run (required)" },
+            "executionDataJson": { "type": "string", "description": "Optional execution data as JSON string for parameterized pipeline runs (optional)", "nullable": true }
+          },
+          "required": ["workspaceId", "pipelineId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "GetPipelineRunStatusAsync",
+        "description": "Gets the status of a Pipeline run (job instance). Possible statuses: NotStarted, InProgress, Completed, Failed, Cancelled, Deduped.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the pipeline (required)" },
+            "pipelineId": { "type": "string", "description": "The pipeline ID (required)" },
+            "jobInstanceId": { "type": "string", "description": "The job instance ID returned from RunPipelineAsync (required)" }
+          },
+          "required": ["workspaceId", "pipelineId", "jobInstanceId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "CreatePipelineScheduleAsync",
+        "description": "Creates a schedule for a Pipeline. Supports Cron, Daily, Weekly, and Monthly schedule types. An item can have up to 20 schedules.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the pipeline (required)" },
+            "pipelineId": { "type": "string", "description": "The pipeline ID to schedule (required)" },
+            "enabled": { "type": "boolean", "description": "Whether the schedule is enabled (required)" },
+            "configurationJson": { "type": "string", "description": "The schedule configuration as JSON string (required). Supported types: Cron, Daily, Weekly, Monthly." }
+          },
+          "required": ["workspaceId", "pipelineId", "enabled", "configurationJson"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "ListPipelineSchedulesAsync",
+        "description": "Lists all schedules for a Pipeline. Returns schedule configurations, status, and owner information.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the pipeline (required)" },
+            "pipelineId": { "type": "string", "description": "The pipeline ID to list schedules for (required)" },
+            "continuationToken": { "type": "string", "description": "A token for retrieving the next page of results (optional)", "nullable": true }
+          },
+          "required": ["workspaceId", "pipelineId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "ListCopyJobsAsync",
+        "description": "Returns a list of Copy Jobs from the specified workspace. This API supports pagination.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID to list copy jobs from (required)" },
+            "continuationToken": { "type": "string", "description": "A token for retrieving the next page of results (optional)", "nullable": true }
+          },
+          "required": ["workspaceId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "CreateCopyJobAsync",
+        "description": "Creates a Copy Job in the specified workspace.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID where the copy job will be created (required)" },
+            "displayName": { "type": "string", "description": "The Copy Job display name (required)" },
+            "description": { "type": "string", "description": "The Copy Job description (optional, max 256 characters)", "nullable": true },
+            "folderId": { "type": "string", "description": "The folder ID (optional, defaults to workspace root)", "nullable": true }
+          },
+          "required": ["workspaceId", "displayName"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "GetCopyJobAsync",
+        "description": "Gets the metadata of a Copy Job by ID.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to retrieve (required)" }
+          },
+          "required": ["workspaceId", "copyJobId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "GetCopyJobDefinitionAsync",
+        "description": "Gets the definition of a Copy Job. Contains copy job JSON configuration with base64-encoded parts.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to get the definition for (required)" }
+          },
+          "required": ["workspaceId", "copyJobId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "UpdateCopyJobAsync",
+        "description": "Updates the metadata (displayName and/or description) of a Copy Job.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to update (required)" },
+            "displayName": { "type": "string", "description": "The new display name (optional)", "nullable": true },
+            "description": { "type": "string", "description": "The new description (optional)", "nullable": true }
+          },
+          "required": ["workspaceId", "copyJobId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "UpdateCopyJobDefinitionAsync",
+        "description": "Updates the definition of a Copy Job with provided JSON content. The JSON will be base64-encoded and sent to the API.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to update (required)" },
+            "definitionJson": { "type": "string", "description": "The copy job definition JSON content (required)" }
+          },
+          "required": ["workspaceId", "copyJobId", "definitionJson"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "RunCopyJobAsync",
+        "description": "Runs a Copy Job on demand. Returns a job instance ID that can be used to track the run status with GetCopyJobRunStatusAsync.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to run (required)" },
+            "executionDataJson": { "type": "string", "description": "Optional execution data as JSON string (optional)", "nullable": true }
+          },
+          "required": ["workspaceId", "copyJobId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "GetCopyJobRunStatusAsync",
+        "description": "Gets the status of a Copy Job run (job instance). Possible statuses: NotStarted, InProgress, Completed, Failed, Cancelled, Deduped.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID (required)" },
+            "jobInstanceId": { "type": "string", "description": "The job instance ID returned from RunCopyJobAsync (required)" }
+          },
+          "required": ["workspaceId", "copyJobId", "jobInstanceId"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "CreateCopyJobScheduleAsync",
+        "description": "Creates a schedule for a Copy Job. Supports Cron, Daily, Weekly, and Monthly schedule types. An item can have up to 20 schedules.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to schedule (required)" },
+            "enabled": { "type": "boolean", "description": "Whether the schedule is enabled (required)" },
+            "configurationJson": { "type": "string", "description": "The schedule configuration as JSON string (required). Supported types: Cron, Daily, Weekly, Monthly." }
+          },
+          "required": ["workspaceId", "copyJobId", "enabled", "configurationJson"]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "ListCopyJobSchedulesAsync",
+        "description": "Lists all schedules for a Copy Job. Returns schedule configurations, status, and owner information.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "workspaceId": { "type": "string", "description": "The workspace ID containing the copy job (required)" },
+            "copyJobId": { "type": "string", "description": "The copy job ID to list schedules for (required)" },
+            "continuationToken": { "type": "string", "description": "A token for retrieving the next page of results (optional)", "nullable": true }
+          },
+          "required": ["workspaceId", "copyJobId"]
+        }
+      }
     }
   ]
 }

--- a/skills/connections-authoring-mcp/SKILL.md
+++ b/skills/connections-authoring-mcp/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: connections-authoring-mcp
+description: >
+  Discover, create, and manage Fabric connections and gateways using MCP tools. Uses data-
+  factory-mcp server to list connections with type filtering, inspect credential and gateway
+  bindings, create connections programmatically or via OAuth UI form, discover on-premises
+  and VNet gateways, and provision VNet gateways. Covers the full connection lifecycle:
+  discovery, type compatibility checking, creation, and gateway binding. Use when the user
+  wants to: (1) find existing connections, (2) create a connection via MCP, (3) create an
+  OAuth connection interactively, (4) list or inspect gateways, (5) create a VNet gateway,
+  (6) troubleshoot credential errors, (7) discover supported connection types.
+  Triggers: "list connections", "create connection mcp", "connection oauth", "list gateways",
+  "create gateway", "vnet gateway", "connection types", "fabric connection", "gateway mcp",
+  "connection credential error".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+- [CONNECTIONS-CORE.md](../../common/CONNECTIONS-CORE.md) — Connection model, types, binding lifecycle, troubleshooting
+
+This skill adds: **how to manage connections and gateways** using MCP tools.
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `list_connections` | Find existing connections (filter by type/name) |
+| `get_connection` | Inspect connection details (credential type, gateway, params) |
+| `list_supported_connection_types` | Discover available types and required parameters |
+| `create_connection` | Create connection programmatically |
+| `create_connection_ui` | Create connection via interactive OAuth UI form (MCP App) |
+| `list_gateways` | Discover on-premises, personal, and VNet gateways |
+| `get_gateway` | Inspect gateway details (type, status, cluster members) |
+| `create_virtualnetwork_gateway` | Provision VNet gateway for Azure network isolation |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Call `list_supported_connection_types` before `create_connection` to learn required parameters
+- Use plain `DatasourceId` GUID for binding — NOT composite format
+- Re-add connections after `save_dataflow_definition` (save may wipe bindings)
+
+### PREFER
+- `create_connection_ui` when user has a browser and source requires OAuth
+- `list_connections` before creating — the connection may already exist
+- Validating connections with `execute_query` after binding
+
+### AVOID
+- Creating connections without checking if one already exists
+- Assuming connection parameter formats — always check supported types first
+
+## Decision Tree: Finding or Creating a Connection
+
+```text
+User mentions a data source
+        │
+        ▼
+  list_connections (search all available)
+        │
+   ┌────┴────┐
+   │         │
+ Found    Not found
+   │         │
+   ▼         ▼
+ Extract   User has browser?
+ DatasourceId    │
+   │    ┌────┴────┐
+   │   Yes        No
+   │    │         │
+   │    ▼         ▼
+   │  create_     create_connection
+   │  connection_ (programmatic)
+   │  _ui              │
+   │    │         │
+   │    └────┬────┘
+   │         │
+   │    list_connections again
+   │    (get new DatasourceId)
+   │         │
+   └────┬────┘
+        │
+        ▼
+  Bind to dataflow / copy job
+```
+
+## Interactive vs Programmatic Creation
+
+| Scenario | Tool |
+|----------|------|
+| User in Claude Desktop/claude.ai, OAuth source | `create_connection_ui` |
+| User in Claude Desktop/claude.ai, non-OAuth | Either — UI is easier |
+| API/headless, any source | `create_connection` |
+| User explicitly asks to create programmatically | `create_connection` |
+
+## Programmatic Creation Workflow
+
+```text
+1. list_supported_connection_types   → Learn required params
+2. Collect parameters from user      → server, database, credentials
+3. create_connection                 → Pass type + params + credentials
+4. list_connections                  → Verify, extract DatasourceId
+```
+
+## Supplementary References
+
+| Reference | When |
+|-----------|------|
+| `references/connection-troubleshooting.md` | Credential errors, binding failures, gateway issues |

--- a/skills/connections-authoring-mcp/references/connection-troubleshooting.md
+++ b/skills/connections-authoring-mcp/references/connection-troubleshooting.md
@@ -1,0 +1,20 @@
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Credentials error after save | `save_dataflow_definition` wiped bindings | Re-add via `add_connection_to_dataflow` |
+| Credentials error, connections look bound | Wrong GUID format (composite vs plain) | Use plain `DatasourceId` GUID only |
+| Instant refresh fail (0-3s) on multi-source | Missing connection or missing `AllowCombine` | Bind all connections + add section attribute |
+| Connection exists but `list_connections` doesn't show it | User lacks permission on that connection | Check with workspace admin |
+| `create_connection` fails with param errors | Wrong parameters for connection type | Call `list_supported_connection_types` first |
+| Source behind firewall, connection timeout | Missing or offline gateway | `list_gateways` → check status |
+| Stale connections after reverting multi→single source | `save_dataflow_definition` doesn't remove old bindings | Create a new dataflow; no `remove_connection` tool exists |
+
+---
+
+## What This File Does NOT Cover
+
+- **Destination configuration** (DataDestinations annotation, _DataDestination queries) → see `destinations/` files
+- **M query authoring** (source query logic, transforms) → see `datafactory-core.md`
+- **OAuth token management** (token refresh, expiry) → handled by the platform, not exposed via MCP
+- **Connection sharing/permissions** → managed in Fabric portal, not via MCP tools

--- a/skills/copyjobs-authoring-mcp/SKILL.md
+++ b/skills/copyjobs-authoring-mcp/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: copyjobs-authoring-mcp
+description: >
+  Create, update, and manage Fabric Copy Jobs using MCP tools for bulk data movement. Uses
+  data-factory-mcp server to create Copy Jobs, define source-to-destination column mappings,
+  configure definitions for CDC and batch modes, set up scheduled execution, and trigger
+  on-demand runs. Copy Jobs are a simplified alternative to pipelines for straightforward
+  data movement without complex transformations. Supports read-modify-write workflows for
+  definitions including connection config, type mappings, and upsert keys. Use when the user
+  wants to: (1) create a Copy Job via MCP, (2) configure source and destination mappings,
+  (3) schedule Copy Job execution, (4) run a Copy Job on demand, (5) modify definitions,
+  (6) set up CDC replication. Triggers: "create copy job", "copy job mcp", "schedule copy
+  job", "run copy job", "copy job definition", "bulk data copy fabric", "copy job mapping",
+  "copy job CDC", "data movement fabric".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+- [CONNECTIONS-CORE.md](../../common/CONNECTIONS-CORE.md) — Connection model, binding lifecycle
+
+This skill adds: **how to author Copy Job items** using MCP tools.
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `create_copy_job` | Create new Copy Job in a workspace |
+| `update_copy_job` | Update Copy Job metadata |
+| `update_copy_job_definition` | Set Copy Job JSON definition |
+| `get_copy_job_definition` | Read current definition (read-modify-write) |
+| `get_copy_job` | Get Copy Job metadata |
+| `list_copy_jobs` | Discover Copy Jobs in a workspace |
+| `run_copy_job` | Trigger on-demand execution |
+| `get_copy_job_run_status` | Poll run status |
+| `create_copy_job_schedule` | Set up scheduled execution |
+| `list_copy_job_schedules` | List configured schedules |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Discover connections via `list_connections` before configuring source/destination
+- Use `get_copy_job_definition` before modifying — read-modify-write pattern
+- Verify connection bindings after definition updates
+
+### PREFER
+- Copy Jobs over pipelines for simple source→destination data movement (no transforms)
+- CDC mode for incremental replication when source supports it
+- Explicit column mappings for schema stability
+
+### AVOID
+- Copy Jobs for complex transformations — use Dataflow Gen2 instead
+- Modifying definitions without reading first — may lose configuration
+
+## Copy Job vs Pipeline vs Dataflow
+
+| Scenario | Use |
+|----------|-----|
+| Simple source→dest data movement, no transforms | **Copy Job** |
+| Orchestrate multiple activities with dependencies | **Pipeline** |
+| Complex M transforms, aggregations, multi-source joins | **Dataflow Gen2** |
+
+## End-to-End Workflow
+
+```text
+1. list_workspaces              → Find workspace
+2. list_connections             → Find source and destination connections
+3. create_copy_job              → Create Copy Job
+4. update_copy_job_definition   → Set source, destination, column mappings
+5. run_copy_job                 → Trigger execution
+6. get_copy_job_run_status      → Poll until Completed/Failed
+7. create_copy_job_schedule     → Set up recurring schedule (optional)
+```
+
+## Supplementary References
+
+| Reference | When |
+|-----------|------|
+| `references/copyjob-patterns.md` | CDC configuration, column mapping details, upsert keys |

--- a/skills/copyjobs-authoring-mcp/references/copyjob-patterns.md
+++ b/skills/copyjobs-authoring-mcp/references/copyjob-patterns.md
@@ -1,0 +1,47 @@
+# Copy Job Patterns
+
+## Copy Job Definition Structure
+
+Copy Job definitions specify source-to-destination data movement configuration:
+
+- **Source**: Connection reference, table/file selection, query or filter
+- **Destination**: Target connection, table name, write mode (replace/append)
+- **Column Mappings**: Source→destination column assignments with type conversions
+- **CDC Configuration**: Change data capture settings for incremental replication
+
+## CDC vs Batch Mode
+
+| Mode | When | How |
+|------|------|-----|
+| **Batch** | Full data replacement on each run | Default — copies entire source |
+| **CDC** | Incremental replication | Tracks changes via watermark or change tracking |
+
+### CDC Requirements
+- Source must support change tracking (SQL Server, Azure SQL)
+- Upsert key columns must be specified for merge behavior
+- First run does a full copy; subsequent runs copy only changes
+
+## Column Mapping Patterns
+
+### Automatic Mapping
+Columns are matched by name. Works when source and destination schemas align.
+
+### Explicit Mapping
+Define specific source→destination column assignments:
+- Rename columns during copy
+- Select subset of source columns
+- Apply type conversions
+
+## Write Modes
+
+| Mode | Behavior |
+|------|----------|
+| **Replace** | Drop and recreate destination data each run |
+| **Append** | Add new rows to existing data |
+| **Upsert** | Insert new rows, update existing (requires key columns) |
+
+## When to Use Copy Job vs Dataflow
+
+- **Copy Job**: Straight source→dest movement, minimal or no transforms
+- **Dataflow Gen2**: Complex M transforms, multi-source joins, aggregations, custom logic
+- **Pipeline**: Orchestrate multiple Copy Jobs or Dataflows with dependencies

--- a/skills/copyjobs-consumption-mcp/SKILL.md
+++ b/skills/copyjobs-consumption-mcp/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: copyjobs-consumption-mcp
+description: >
+  Inspect and monitor Fabric Copy Jobs using MCP tools for read-only exploration and run
+  tracking. Uses data-factory-mcp server tools to list Copy Jobs across workspaces, decode
+  Copy Job JSON definitions to examine source and destination configuration and column
+  mappings, poll run status (NotStarted, InProgress, Completed, Failed, Cancelled, Deduped),
+  and list configured schedules. Provides structured discovery: list workspaces, enumerate
+  Copy Jobs, inspect metadata, decode definitions, check run history. Use when the user
+  wants to: (1) browse Copy Jobs in a workspace, (2) inspect Copy Job configuration without
+  modifying, (3) check Copy Job run status or failure reasons, (4) list Copy Job schedules,
+  (5) audit Copy Job definitions, (6) compare source and destination settings across jobs.
+  Triggers: "list copy jobs", "copy job run status", "inspect copy job", "copy job schedules",
+  "browse copy jobs mcp", "copy job monitoring", "copy job history", "what copy jobs exist".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+
+This skill adds: **how to inspect and monitor Copy Jobs** using MCP tools (read-only).
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `list_copy_jobs` | Discover Copy Jobs in a workspace |
+| `get_copy_job` | Read Copy Job metadata |
+| `get_copy_job_definition` | Read Copy Job JSON definition |
+| `get_copy_job_run_status` | Poll run status |
+| `list_copy_job_schedules` | List configured schedules |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Authenticate and discover workspace before inspection
+
+### PREFER
+- Discovery sequence: workspace → copy jobs → definition → run status → schedules
+- Reading definition alongside run status for troubleshooting
+
+### AVOID
+- Modifying definitions — use `copyjobs-authoring-mcp` for writes
+
+## Discovery Sequence
+
+```text
+1. list_workspaces              → Find target workspace
+2. list_copy_jobs               → Enumerate Copy Jobs
+3. get_copy_job                 → Read metadata
+4. get_copy_job_definition      → Decode source/dest configuration
+5. get_copy_job_run_status      → Check last run outcome
+6. list_copy_job_schedules      → See configured schedules
+```
+
+## Run Status Interpretation
+
+| Status | Meaning |
+|--------|---------|
+| `Completed` | Copy succeeded |
+| `Failed` | Copy failed — check error details for schema mismatch, auth, or connectivity |
+| `InProgress` | Still running |
+| `Cancelled` | User or system cancelled |
+| `NotStarted` | Queued |
+| `Deduped` | Skipped — another run already in progress |

--- a/skills/datafactory-operations-mcp/SKILL.md
+++ b/skills/datafactory-operations-mcp/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: datafactory-operations-mcp
+description: >
+  Diagnose and triage operational issues across Fabric Data Factory items using MCP tools.
+  Provides cross-item troubleshooting for dataflow refresh failures, pipeline run failures,
+  copy job errors, and connection credential problems. Uses data-factory-mcp server to check
+  status across item types, validate connection bindings, inspect errors, and identify common
+  failure patterns (DataflowNeverPublishedError, credentials, timeout, schema mismatch).
+  Covers symptom-based triage with decision trees. Use when the user wants to:
+  (1) troubleshoot a failed dataflow refresh, (2) diagnose a pipeline run failure,
+  (3) debug credential errors, (4) triage copy job failures, (5) understand why a scheduled
+  job didn't run, (6) check health across items. Triggers: "dataflow failed", "pipeline
+  failed", "copy job error", "credential error", "refresh failed", "troubleshoot data
+  factory", "why did my dataflow fail", "DataflowNeverPublishedError", "diagnostics".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, error handling
+- [CONNECTIONS-CORE.md](../../common/CONNECTIONS-CORE.md) — Connection troubleshooting matrix
+
+This skill adds: **cross-item operational triage** for Data Factory.
+
+## Symptom Triage
+
+| Symptom | Likely Cause | Investigation |
+|---------|-------------|---------------|
+| `DataflowNeverPublishedError` | Default `SkipApplyChanges` on first run | Use `ApplyChangesIfNeeded` |
+| `DestinationColumnNotFound` | Manual mappings for new table | Switch to `Kind = "Automatic"` |
+| Credentials error on refresh | Connection binding wiped by save | Re-add via `add_connection_to_dataflow` |
+| Instant refresh fail (0-3s) | Privacy firewall or unpublished draft | Add `[AllowCombine = true]` and/or `ApplyChangesIfNeeded` |
+| FastCopy fails with transforms | Unsupported transform in Fast Copy mode | Remove `[StagingDefinition]` |
+| Pipeline shows Failed | Underlying activity failed | Check item-level status (dataflow/copy job) |
+| Copy Job schema mismatch | Source schema changed | Inspect definition, update column mappings |
+| Scheduled job didn't run | Schedule not configured or paused | `list_*_schedules` to verify |
+| Multi-source instant fail | Dirty dataflow or separate Lakehouse.Contents | Create fresh dataflow |
+| Stale connections after revert | save_dataflow_definition doesn't remove old bindings | Create new dataflow |
+
+## Triage Decision Tree
+
+```text
+Item failed
+    │
+    ├── Dataflow?
+    │     └── refresh_dataflow_status → check error
+    │           ├── Credentials → re-bind connections
+    │           ├── NeverPublished → ApplyChangesIfNeeded
+    │           ├── Timeout → chunk query (see performance patterns)
+    │           └── M syntax → inspect definition, fix code
+    │
+    ├── Pipeline?
+    │     └── get_pipeline_run_status → find failed activity
+    │           └── Check underlying item status
+    │
+    └── Copy Job?
+          └── get_copy_job_run_status → check error
+                ├── Schema mismatch → inspect definition
+                ├── Auth failure → check connection
+                └── Timeout → check data volume
+```
+
+## Connection Health Check
+
+When a credential error occurs across any item type:
+
+```text
+1. list_connections                 → Verify connection exists
+2. get_connection                  → Check credential type, gateway binding
+3. add_connection_to_dataflow      → Re-bind (if dataflow)
+4. execute_query                   → Validate with lightweight query
+```
+
+## Must / Prefer / Avoid
+
+### MUST
+- Check item-specific status before diagnosing (don't guess)
+- Start from symptoms, not assumptions
+- Verify connection bindings as first step for auth errors
+
+### PREFER
+- Cross-referencing run status with definition state
+- Checking schedule configuration when "job didn't run"
+- Using the symptom triage table above as the starting point
+
+### AVOID
+- Modifying items during triage — diagnose first, then fix via authoring skills
+- Assuming the pipeline is the root cause when an underlying activity failed

--- a/skills/dataflows-authoring-mcp/SKILL.md
+++ b/skills/dataflows-authoring-mcp/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: dataflows-authoring-mcp
+description: >
+  Create, update, and manage Fabric Dataflows Gen2 using MCP tools with Power Query M mashup
+  definitions. Uses data-factory-mcp server tools to author M section documents, bind connections,
+  trigger refresh jobs with ApplyChangesIfNeeded, and run ad-hoc M queries returning Apache Arrow
+  results. Covers destination configuration for Lakehouse/Warehouse targets with DataDestinations
+  annotations, multi-source patterns with AllowCombine, connection re-binding after save, and
+  rolling date windows. Use when the user wants to: (1) create a new Dataflow Gen2 via MCP,
+  (2) update queries in an existing dataflow, (3) trigger and monitor refresh jobs, (4) bind
+  connections to dataflows, (5) run ad-hoc M queries, (6) configure staging destinations.
+  Triggers: "create dataflow mcp", "dataflow M query", "refresh dataflow", "bind connection
+  dataflow", "execute M query", "dataflow gen2 mcp", "add query to dataflow", "dataflow arrow
+  results", "fast copy dataflow", "action sequence", "dataflow destination".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+- [CONNECTIONS-CORE.md](../../common/CONNECTIONS-CORE.md) — Connection model, binding lifecycle, troubleshooting
+
+This skill adds: **how to author Dataflow Gen2 items** using MCP tools.
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `create_dataflow` | Create new empty dataflow in a workspace |
+| `save_dataflow_definition` | Save complete M section document (queries + destinations) |
+| `add_connection_to_dataflow` | Bind connections to dataflow (before AND after save) |
+| `add_or_update_query_in_dataflow` | Add or update individual queries |
+| `execute_query` | Run M queries ad-hoc, returns Apache Arrow results |
+| `refresh_dataflow_background` | Trigger async refresh job |
+| `refresh_dataflow_status` | Poll refresh job for completion |
+| `get_dataflow_definition` | Read current M section document (read-modify-write) |
+| `list_dataflows` | Discover dataflows in a workspace |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Use `executeOption = "ApplyChangesIfNeeded"` on first refresh of API-created dataflows
+- Re-add connections via `add_connection_to_dataflow` after `save_dataflow_definition` (save may wipe them)
+- Use `list_workspaces` and filter by name — there is no `find_workspace` tool
+- Validate each connection with `execute_query` after binding
+- Create a new dataflow for multi-source — never convert a published single-source dataflow
+
+### PREFER
+- Filter early in M queries to enable query folding (push filters to source)
+- Expensive operations (sort, aggregate) last — streaming operations (filter, select) first
+- `execute_query` with `customMashupDocument` to iterate on M code before saving
+- Standard engine for complex transforms; Fast Copy only for simple ingestion
+- Rolling date windows over hardcoded dates for scheduled dataflows
+
+### AVOID
+- `get_authoring_guidance` — deprecated, author M directly
+- Sorting early in query chains (reads all data before returning)
+- `SELECT *` without row limits during development — use "Keep First Rows" then remove
+- `IsNewTarget = false` on API-created dataflows — always use `IsNewTarget = true` with `?[Data]?`
+
+## End-to-End Workflow: New Dataflow with Lakehouse Destination
+
+```text
+1. list_workspaces              → Find workspace, extract workspaceId
+2. create_dataflow              → Create empty dataflow
+3. list_connections             → Find connection for your source
+4. add_connection_to_dataflow   → Bind source connection(s)
+5. execute_query                → Discover target lakehouse ID
+6. save_dataflow_definition     → Save M document with source + DataDestinations
+7. add_connection_to_dataflow   → Re-bind connections (save may wipe them)
+8. get_dataflow_definition      → Verify connections + destination config
+9. refresh_dataflow_background  → Materialize; MUST use ApplyChangesIfNeeded
+10. refresh_dataflow_status     → Poll until Completed/Failed
+```
+
+## Destination Configuration
+
+### New Table (Most Common Path)
+
+Place `[DataDestinations]` annotation before the source query:
+
+```m
+[DataDestinations = {[
+  Definition = [Kind = "Reference", QueryName = "MyQuery_DataDestination", IsNewTarget = true],
+  Settings = [Kind = "Automatic", TypeSettings = [Kind = "Table"]]
+]}]
+shared MyQuery = let ... in Result;
+
+shared MyQuery_DataDestination = let
+  Pattern = Lakehouse.Contents([HierarchicalNavigation = null, CreateNavigationProperties = false, EnableFolding = false]),
+  Nav1 = Pattern{[workspaceId = "..."]}[Data],
+  Nav2 = Nav1{[lakehouseId = "..."]}[Data],
+  TableNav = Nav2{[Id = "MyQuery", ItemKind = "Table"]}?[Data]?
+in TableNav;
+```
+
+Key requirements:
+- `IsNewTarget = true` always for API-created dataflows (even for existing tables)
+- `?[Data]?` null-safe operators (table doesn't exist on first refresh)
+- `Kind = "Automatic"` (Manual validates columns before table exists)
+- `_DataDestination` suffix naming convention for hidden query
+
+### Discovering Lakehouse IDs
+
+```m
+let
+  Source = Lakehouse.Contents(null),
+  Navigation = Source{[workspaceId = "your-workspace-id"]}[Data]
+in Navigation
+```
+
+Returns `lakehouseId`, `lakehouseName`, `databaseId` for each lakehouse.
+
+## M Language Basics
+
+M (Power Query Formula Language) is functional, case-sensitive, lazy-evaluated.
+
+```m
+let
+    Source = Lakehouse.Contents(null),
+    Filtered = Table.SelectRows(Source, each [Status] = "Active"),
+    Result = Table.SelectColumns(Filtered, {"ID", "Name"})
+in Result
+```
+
+## Rolling Date Windows
+
+Use for scheduled dataflows instead of hardcoded dates:
+
+| Window | Start | End |
+|--------|-------|-----|
+| Last N months | `Date.StartOfMonth(Date.AddMonths(today, -N))` | `Date.EndOfMonth(Date.AddMonths(today, -1))` |
+| Current quarter | `Date.StartOfQuarter(today)` | `today` |
+| Year to date | `#date(Date.Year(today), 1, 1)` | `today` |
+
+## What-If Query Pattern
+
+Create derivative queries that reference a materialized output to model scenarios without duplicating source logic:
+
+```m
+shared WhatIf_Reclassify = let
+  Source = MaterializedQuery,
+  Reclassed = Table.AddColumn(Source, "new_tier",
+    each if [store_name] = "Tacoma" then "C" else [tier], type text)
+in Reclassed;
+```
+
+## Supplementary References
+
+Load on demand based on the task:
+
+| Reference | When |
+|-----------|------|
+| `references/performance-patterns.md` | Query timeouts, chunking, query folding strategies |
+| `references/advanced-features.md` | Fast Copy, Action.Sequence, Modern Evaluator |
+| `references/source-patterns.md` | Multi-source with AllowCombine, SharePoint Excel |
+| `references/destination-patterns.md` | Destination troubleshooting, existing table patterns |

--- a/skills/dataflows-authoring-mcp/references/advanced-features.md
+++ b/skills/dataflows-authoring-mcp/references/advanced-features.md
@@ -1,0 +1,139 @@
+# Advanced: Action.Sequence, Fast Copy, Modern Evaluator
+
+## Action.Sequence (Side Effects / Writes)
+
+`Action.Sequence` is for **side-effecting operations** (writes, mutations) - NOT for normal query transformations.
+
+### When to Use
+
+| Scenario | Use Action.Sequence? |
+|----------|---------------------|
+| Filters, joins, transforms | NO - use normal `let ... in` |
+| Write files to blob/ADLS | YES |
+| Parallel file outputs | YES |
+| Calculated columns, type changes | NO |
+
+### Key Primitives
+
+- `Action.Sequence({...})` - forces ordered execution of actions
+- `Action.DoNothing` - no-op (often ends a sequence)
+- `ValueAction.Replace(target, source)` - write/replace to storage
+- `ListAction.ParallelExecute({...})` - run action units concurrently
+
+### Pattern: Parallel File Writes
+
+```m
+// Function that writes a single file
+shared go = (i) => Action.Sequence({
+  ValueAction.Replace(
+    AzureStorage.BlobContents("https://storage.blob.core.windows.net/container/output" & Text.From(i) & ".csv"),
+    sourceData
+  ),
+  Action.DoNothing
+});
+
+// Execute 4 writes in parallel
+shared writeAll = ListAction.ParallelExecute({
+  () => go(0),
+  () => go(1),
+  () => go(2),
+  () => go(3)
+});
+```
+
+### Mental Model
+
+- **Parallelism across units** → `ListAction.ParallelExecute`
+- **Ordering within a unit** → `Action.Sequence`
+
+### Best Practices
+
+1. **Isolate side effects** - keep action logic in dedicated queries, main transforms stay pure
+2. **Make actions idempotent** - retries happen; ensure repeating won't corrupt state
+3. **Don't parallelize competing resources** - `Action.Sequence` orders inside one unit, not across parallel units
+4. **Handle failures** - wrap risky actions with `try ... otherwise ...`
+
+### Rule of Thumb
+
+- Query returns a **table/value** → normal `let` pipeline
+- Query performs **writes/side effects** with guaranteed ordering → `Action.Sequence`
+
+---
+
+## Fast Copy
+
+Fast copy uses pipeline Copy Activity backend for faster ingestion. Enable with:
+```m
+[StagingDefinition = [Kind = "FastCopy"]]
+section Section1;
+```
+
+### Supported Transformations Only
+
+Fast copy **only** supports:
+- Combine files
+- Select columns
+- Change data types
+- Rename/remove columns
+
+### NOT Supported by Fast Copy
+
+- `Table.Group` (aggregations)
+- Complex joins
+- Custom transformations
+
+**If your query uses unsupported transformations (like Group By), omit the StagingDefinition annotation entirely.**
+
+### Splitting Queries for Performance
+
+For large data with complex transformations:
+1. Create first query with fast copy (ingestion only, supported transforms)
+2. Enable staging on first query
+3. Create second query that references first query
+4. Apply complex transformations (Group By, etc.) in second query
+
+This gives you fast copy speed for ingestion + SQL DW compute for transformations.
+
+### Output Destination Limitation
+
+Fast copy only supports Lakehouse destinations directly. For other destinations, stage first then reference.
+
+---
+
+## Modern Evaluator (Preview)
+
+The Modern Query Evaluation Engine is for **Dataflow Gen2 with CI/CD** specifically. Runs on .NET Core 8.
+
+### Fast Copy vs Modern Evaluator
+
+| Feature | Fast Copy | Modern Evaluator |
+|---------|-----------|------------------|
+| Purpose | Faster **ingestion** | Faster **query evaluation** |
+| Limitation | Limited transformations | Limited connectors |
+| Complex transforms | Not supported | Supported |
+| Enable via | `[StagingDefinition = [Kind = "FastCopy"]]` | UI: Options > Scale tab |
+
+### When to Use Each
+- **Fast Copy**: Large data, simple transforms (select/rename columns only)
+- **Modern Evaluator**: Complex transforms (Group By, joins), supported connectors
+- **Neither**: Complex transforms with unsupported connectors - use standard engine
+
+### Supported Connectors (Modern Evaluator)
+- Azure Blob Storage / ADLS Gen2
+- Fabric Lakehouse / Warehouse
+- OData
+- Power Platform Dataflows
+- SharePoint Online List / Folder
+- Web
+
+### Enabling
+Via Fabric UI: Options > Scale tab > "Modern query evaluation engine (Preview)"
+
+In queryMetadata.json (observed in working dataflows):
+```json
+"computeEngineSettings": {
+  "allowModernEvaluationEngine": true
+}
+```
+
+Note: MCP `save_dataflow_definition` updates M code but may not set computeEngineSettings. Enable via UI if needed.

--- a/skills/dataflows-authoring-mcp/references/destination-patterns.md
+++ b/skills/dataflows-authoring-mcp/references/destination-patterns.md
@@ -1,0 +1,227 @@
+# New Table Destination Pattern
+
+Creating a new output table in Lakehouse via MCP tools. This is the most common programmatic destination path.
+
+## Required Components
+
+### 1. DataDestinations Annotation
+
+Place immediately before the source query. **Must use `Automatic`** — Manual validates column mappings against a table that doesn't exist yet, causing `DestinationColumnNotFound`.
+
+```m
+[DataDestinations = {[
+  Definition = [Kind = "Reference", QueryName = "MyQuery_DataDestination", IsNewTarget = true],
+  Settings = [Kind = "Automatic", TypeSettings = [Kind = "Table"]]
+]}]
+shared MyQuery = let
+  // source query logic
+in
+  Result;
+```
+
+### 2. Hidden Destination Query
+
+**Must use `?` null-safe operators** — the table doesn't exist on first refresh, so direct `[Data]` navigation fails with "The key didn't match any rows in the table."
+
+```m
+shared MyQuery_DataDestination = let
+  Pattern = Lakehouse.Contents([HierarchicalNavigation = null, CreateNavigationProperties = false, EnableFolding = false]),
+  Navigation_1 = Pattern{[workspaceId = "your-workspace-id"]}[Data],
+  Navigation_2 = Navigation_1{[lakehouseId = "your-target-lakehouse-id"]}[Data],
+  TableNavigation = Navigation_2{[Id = "MyQuery", ItemKind = "Table"]}?[Data]?
+in
+  TableNavigation;
+```
+
+### 3. Complete Section Document
+
+Submit via `save_dataflow_definition`:
+
+```m
+section Section1;
+
+[DataDestinations = {[
+  Definition = [Kind = "Reference", QueryName = "MyQuery_DataDestination", IsNewTarget = true],
+  Settings = [Kind = "Automatic", TypeSettings = [Kind = "Table"]]
+]}]
+shared MyQuery = let
+  Source = Lakehouse.Contents(null),
+  Nav = Source{[workspaceId = "..."}]}[Data],
+  DB = Nav{[lakehouseId = "..."]}[Data],
+  // transform logic
+  Result = DB
+in
+  Result;
+
+shared MyQuery_DataDestination = let
+  Pattern = Lakehouse.Contents([HierarchicalNavigation = null, CreateNavigationProperties = false, EnableFolding = false]),
+  Navigation_1 = Pattern{[workspaceId = "..."]}[Data],
+  Navigation_2 = Navigation_1{[lakehouseId = "..."]}[Data],
+  TableNavigation = Navigation_2{[Id = "MyQuery", ItemKind = "Table"]}?[Data]?
+in
+  TableNavigation;
+```
+
+## MCP Tool Workflow (7 Steps)
+
+```
+1. create_dataflow              → Create empty dataflow
+2. add_connection_to_dataflow   → Attach ALL source connections
+3. execute_query                → Discover target lakehouse ID
+4. save_dataflow_definition     → Save complete M document with destination config
+5. add_connection_to_dataflow   → Re-add connections (save may wipe them)
+6. get_dataflow_definition      → Verify connections + destination config
+7. refresh_dataflow_background  → Materialize the table
+                                   MUST use executeOption="ApplyChangesIfNeeded"
+```
+
+## Why `ApplyChangesIfNeeded` Is Required
+
+API-created dataflows start in an unpublished draft state. `save_dataflow_definition` sets `loadEnabled: false` in queryMetadata. The platform reconciles both issues on refresh ONLY when using `ApplyChangesIfNeeded`.
+
+| Refresh Option | Behavior on MCP-created dataflow |
+|---|---|
+| `SkipApplyChanges` (default) | **Instant failure** — stale metadata, draft never published |
+| `ApplyChangesIfNeeded` | Re-parses M annotations, publishes draft, reconciles metadata, then executes |
+
+After the first successful refresh, subsequent refreshes can use either option.
+
+## Discovering Lakehouse IDs
+
+Use `execute_query` to list available lakehouses in a workspace:
+
+```m
+let
+  Source = Lakehouse.Contents(null),
+  Navigation = Source{[workspaceId = "your-workspace-id"]}[Data]
+in
+  Navigation
+```
+
+Returns: `lakehouseId`, `lakehouseName`, `databaseId` for each lakehouse.
+
+## Key Details
+
+| Element | Requirement |
+|---------|-------------|
+| `_DataDestination` suffix | Required naming convention for hidden query |
+| `EnableFolding = false` | Required in destination query pattern |
+| `isHidden = true` | Automatically set in queryMetadata for destination queries |
+| Target table ID | Uses source query name (table created on first refresh) |
+
+For connection binding workflow and connection ID format → see `datafactory-connections.md`.
+
+## `IsNewTarget = true` Always for API-Created Dataflows
+
+Even when targeting a table that already exists, use `IsNewTarget = true` with `?[Data]?` null-safe operators. `IsNewTarget = false` with direct `[Data]` navigation fails on first refresh of API-created dataflows.
+
+---
+
+# Existing Table Destination Pattern
+
+Writing to a Lakehouse table that already exists. Use when you need precise control over column mappings and update behavior.
+
+> **API-created dataflows (via MCP tools):** Use `dest-new-table.md` instead — even for existing tables. `IsNewTarget = true` with `?[Data]?` null-safe operators is required for first refresh of API-created dataflows. The pattern below is for dataflows created or already published through the Fabric UI.
+
+## DataDestinations Annotation
+
+```m
+[DataDestinations = {[
+  Definition = [Kind = "Reference", QueryName = "MyQuery_DataDestination", IsNewTarget = false],
+  Settings = [
+    Kind = "Manual",
+    AllowCreation = false,
+    DynamicSchema = false,
+    UpdateMethod = [Kind = "Replace"],
+    TypeSettings = [Kind = "Table"]
+  ]
+]}]
+shared MyQuery = let
+  // source query logic
+in
+  Result;
+```
+
+## Hidden Destination Query
+
+Uses direct `[Data]` navigation (no null-safe operators) — the table must exist.
+
+```m
+shared MyQuery_DataDestination = let
+  Pattern = Lakehouse.Contents([HierarchicalNavigation = null, CreateNavigationProperties = false, EnableFolding = false]),
+  Navigation_1 = Pattern{[workspaceId = "your-workspace-id"]}[Data],
+  Navigation_2 = Navigation_1{[lakehouseId = "your-target-lakehouse-id"]}[Data],
+  TableNavigation = Navigation_2{[Id = "MyQuery", ItemKind = "Table"]}[Data]
+in
+  TableNavigation;
+```
+
+## Automatic vs Manual Settings
+
+| Setting | `Kind = "Automatic"` | `Kind = "Manual"` |
+|---------|---------------------|-------------------|
+| Mapping | Managed for you | Explicit `ColumnSettings` required |
+| Schema changes | Allowed (table dropped/recreated) | Must match exactly |
+| Use case | New tables, flexible schema | Existing tables, preserve relationships |
+
+## Update Methods
+
+- **Replace**: Data dropped and replaced each refresh
+- **Append**: Output appended to existing data
+
+## Staging Requirements
+
+- **Warehouse destination**: Staging REQUIRED (enable on query)
+- **Lakehouse destination**: Staging disabled by default for performance
+
+## API-Created Dataflows
+
+Do not use this pattern for API-created dataflows. Use `dest-new-table.md` with `IsNewTarget = true` and `?[Data]?` null-safe operators — even when the table already exists. After the first successful refresh, you can switch to this pattern if needed.
+
+---
+
+# Destination Troubleshooting
+
+## Common Pitfalls — Expanded
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `DataflowNeverPublishedError` | Default `SkipApplyChanges` on first run | `executeOption = "ApplyChangesIfNeeded"` |
+| `DestinationColumnNotFound` | Manual mappings for new table | Use `Kind = "Automatic"`, no `ColumnSettings` |
+| Credentials error on Lakehouse | Connection not bound | `add_connection_to_dataflow` then validate |
+| FastCopy fails with transforms | `Table.Group`, `NestedJoin`, etc. | Remove `[StagingDefinition]` |
+| Instant refresh fail (0-3s) | Privacy firewall or unpublished | `[AllowCombine = true]` and/or `ApplyChangesIfNeeded` |
+| `loadEnabled: false` in metadata | Controls data staging, not destinations | Not a problem with `DataDestinations` + `ApplyChangesIfNeeded` |
+| Multi-source instant fail via API | Dirty dataflow or separate Lakehouse.Contents | Create fresh dataflow; consolidate reads |
+| Lakehouse-only fails after revert | `save_dataflow_definition` doesn't remove stale connections | Create new dataflow; no `remove_connection` tool |
+| `IsNewTarget = false` fails on API-created | Direct `[Data]` navigation fails on first refresh | Use `IsNewTarget = true` with `?[Data]?` null-safe operators |
+
+## Detailed Explanations
+
+### `DataflowNeverPublishedError`
+API-created dataflows start in an unpublished draft state. The default refresh option (`SkipApplyChanges`) skips metadata reconciliation, so the draft never gets published. Always use `ApplyChangesIfNeeded` on the first refresh — it re-parses M annotations, publishes the draft, and reconciles metadata before executing.
+
+### `DestinationColumnNotFound`
+When `Kind = "Manual"` is set, the engine validates column mappings against the destination table BEFORE creating it. Since the table doesn't exist yet, every column fails validation. Use `Kind = "Automatic"` for new tables — it infers and creates the schema on first refresh.
+
+### Stale Connections After Revert
+`save_dataflow_definition` does NOT remove connections from queryMetadata — it only adds/updates them. If you convert a multi-source dataflow back to single-source, the old connections remain as ghost metadata, causing failures. There is no `remove_connection` tool. Create a new dataflow instead.
+
+### `loadEnabled: false`
+`save_dataflow_definition` sets `loadEnabled: false` in queryMetadata. This controls whether data is staged during transformations, not whether the destination is configured. With `DataDestinations` annotations and `ApplyChangesIfNeeded`, this is reconciled automatically.
+
+### `IsNewTarget = false` on API-Created Dataflows
+Direct `[Data]` navigation (without `?` null-safe operators) combined with `IsNewTarget = false` fails on first refresh of API-created dataflows. The table navigation step runs before the platform reconciles metadata, finding no table. Always use `IsNewTarget = true` with `?[Data]?` for first-time API setup, even for existing tables.
+
+## New Table vs Existing Table Summary
+
+| Scenario | `IsNewTarget` | `AllowCreation` | Navigation |
+|----------|---------------|-----------------|------------|
+| Table doesn't exist yet | `true` | `true` | `?[Data]?` (null-safe) |
+| Table already exists (UI-created dataflow) | `false` | `false` | `[Data]` (direct) |
+| Table already exists (API-created dataflow) | `true` | `true` | `?[Data]?` (null-safe) — use `dest-new-table.md` pattern |
+
+## Edge Cases
+
+- **Connection binding and ID format**: See `datafactory-connections.md` for binding workflow, GUID format, and `clearExisting` usage.
+- **Warehouse destinations**: Staging is REQUIRED. Lakehouse destinations have staging disabled by default for performance.

--- a/skills/dataflows-authoring-mcp/references/performance-patterns.md
+++ b/skills/dataflows-authoring-mcp/references/performance-patterns.md
@@ -1,0 +1,78 @@
+# Data Factory Performance & Query Organization
+
+## Query Performance
+
+### Handling Timeouts
+
+When a query times out, chunk by a key column (e.g., date, ID, region) to process data in smaller batches.
+
+Example approach:
+1. Identify a suitable partitioning column (dates work well)
+2. Run the query for smaller ranges (e.g., one month at a time)
+3. Aggregate results as needed
+
+### Filter Early
+
+Apply filters as early as possible in your query. This enables query folding (pushing filters to the data source) and reduces data volume for subsequent steps.
+
+### Expensive Operations Last
+
+Operations like sorting require reading all data before returning results. Place these at the end. Streaming operations (filters, column selection) can go first since they process data incrementally.
+
+### Work on a Subset During Development
+
+When building queries, use "Keep First Rows" to limit data during development. Remove this step once your transformations are complete.
+
+---
+
+## Connectors & Data Types
+
+### Choose the Right Connector
+
+Use native connectors (e.g., SQL Server connector) over generic ones (ODBC/OLEDB). Native connectors offer better query folding and optimized performance.
+
+### Set Correct Data Types
+
+Always define data types explicitly, especially for unstructured sources (CSV, TXT). Type-specific filters and transformations only appear when columns have correct types assigned.
+
+---
+
+## Query Organization
+
+### Modular Queries
+
+Split large queries into smaller referenced queries. Use "Extract Previous" to break a query at a specific step. This improves readability and reusability.
+
+### Use Groups
+
+Organize queries into groups (folders) in the Queries pane. Drag and drop to reorganize.
+
+### Document Steps
+
+Rename steps and add descriptions in the Applied Steps pane. Future you will thank present you.
+
+---
+
+## Parameters & Functions
+
+### Use Parameters
+
+Store reusable values (server names, file paths, filter values) as parameters. Update once, apply everywhere.
+
+### Create Reusable Functions
+
+When applying the same transformations to multiple queries, create a custom function. Right-click a query → "Create Function".
+
+---
+
+## Future-Proofing
+
+### Handle Dynamic Data
+
+- Use "Remove bottom rows" for footers (not row filters)
+- Use "Choose columns" to select specific columns (survives new columns being added)
+- Use "Unpivot only selected columns" when column count varies
+
+### Handle Errors Gracefully
+
+If type conversions cause errors, consider removing error rows or replacing errors with defaults.

--- a/skills/dataflows-authoring-mcp/references/source-patterns.md
+++ b/skills/dataflows-authoring-mcp/references/source-patterns.md
@@ -1,0 +1,98 @@
+# Multi-Source Dataflows: AllowCombine
+
+When a dataflow combines multiple source types (e.g., Lakehouse + SharePoint, Lakehouse + Web), the mashup engine's privacy firewall blocks cross-source queries by default. This causes instant "Validation failure" on refresh with no detailed error.
+
+## Fix: Section-Level AllowCombine
+
+```m
+[AllowCombine = true]
+section Section1;
+
+shared LakehouseQuery = let ... in ...;
+shared SharePointQuery = let ... in ...;
+shared JoinedOutput = let ... in ...;
+```
+
+## Symptom Table
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Instant refresh failure (0-3 seconds) | Privacy firewall blocking cross-source | Add `[AllowCombine = true]` before `section` |
+| "Validation failure" with no details | Same — pre-execution metadata check | Same |
+| Works in UI but fails via MCP | UI auto-prompts for privacy; API does not | Must set explicitly in M document |
+
+**Critical:** Required for any dataflow that mixes source types. Single-source dataflows (Lakehouse-only) do not need it.
+
+## Multi-Source via API: Requirements
+
+Multi-source dataflows **work via API** with `[AllowCombine = true]`, but require specific conditions:
+
+1. **Fresh dataflow** — Always create a new dataflow for multi-source. Never transition a previously-published single-source dataflow to multi-source; stale connection metadata persists and causes instant refresh failure.
+2. **Consolidated Lakehouse reads** — Read all Lakehouse tables in a single source query (one `Lakehouse.Contents` call), not separate queries per table. Reduces the number of distinct data source contexts the privacy firewall must reconcile.
+3. **All connections bound** — Add all connections (Lakehouse, Web/SharePoint) via `add_connection_to_dataflow` before and after `save_dataflow_definition`.
+4. **`ApplyChangesIfNeeded`** — Required on first refresh of any API-created dataflow.
+
+## Pattern That Works
+
+```
+StoreActuals     → Single query: Lakehouse.Contents → reads orders, items, stores → aggregates
+StoreTargets     → Excel.Workbook(Web.Contents("...sharepoint.com/.../file.xlsx"))
+StoreAnnotations → Excel.Workbook(Web.Contents("...sharepoint.com/.../file.xlsx"))
+OutputQuery      → Joins StoreActuals + StoreTargets + StoreAnnotations, with DataDestination
+```
+
+## What Causes Failure
+
+| Scenario | Result |
+|----------|--------|
+| Fresh dataflow + consolidated reads + AllowCombine | Works |
+| Previously-published single-source converted to multi-source | Instant failure — stale metadata |
+| Separate `Lakehouse.Contents` calls per source query | May fail — multiple data source contexts |
+
+---
+
+# SharePoint Excel Source Pattern
+
+Reading Excel files from SharePoint in Dataflow Gen2 uses a **Web connection** (not the SharePoint connector).
+
+## M Pattern
+
+```m
+shared ExcelSource = let
+    WB = Excel.Workbook(
+        Web.Contents("https://<tenant>.sharepoint.com/teams/<site>/Shared Documents/<file>.xlsx"),
+        null,
+        true
+    ),
+    Sheet = WB{[Item = "<SheetName>", Kind = "Sheet"]}[Data],
+    Headers = Table.PromoteHeaders(Sheet, [PromoteAllScalars = true]),
+    Typed = Table.TransformColumnTypes(Headers, {
+        {"col1", type text},
+        {"col2", type number}
+    })
+in
+    Typed;
+```
+
+## Connection Requirements
+
+- Requires a **Web** connection to the SharePoint site URL
+- Find via `list_connections` filtering for `connectionType: "Web"` with a URL containing `.sharepoint.com`
+- If no matching connection exists, create one with `create_connection` or `create_connection_ui`
+
+## MCP Workflow
+
+```
+1. list_connections              → Find Web connection with .sharepoint.com URL
+   (if not found)                → create_connection_ui or create_connection
+2. create_dataflow               → Create empty dataflow
+3. add_connection_to_dataflow    → Bind the Web connection (+ Lakehouse if writing output)
+4. save_dataflow_definition      → Save M document with SharePoint source + DataDestination
+5. add_connection_to_dataflow    → Re-add connections (save may wipe them)
+6. execute_query                 → Validate source reads successfully
+7. refresh_dataflow_background   → Materialize; use ApplyChangesIfNeeded on first refresh
+```
+
+## Multi-Source Note
+
+When combining SharePoint data with Lakehouse data, you must add `[AllowCombine = true]` to the section. See `sources/multi-source.md` for the full pattern.

--- a/skills/dataflows-consumption-mcp/SKILL.md
+++ b/skills/dataflows-consumption-mcp/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: dataflows-consumption-mcp
+description: >
+  Inspect and monitor Fabric Dataflows Gen2 using MCP tools for read-only exploration. Uses
+  data-factory-mcp server tools to list dataflows across workspaces, decode base64 mashup.pq
+  definitions to examine M query logic, inspect connection bindings and staging settings in
+  queryMetadata.json, discover typed parameters with defaults, and poll refresh job status for
+  completion timing and error details. Provides structured discovery: list workspaces, enumerate
+  dataflows, inspect properties, decode definitions, check refresh history. Use when the user
+  wants to: (1) browse dataflows in a workspace, (2) inspect M query logic without modifying,
+  (3) check refresh status or failure reasons, (4) discover dataflow parameters and settings,
+  (5) analyze staging and connection configuration, (6) audit dataflow definitions.
+  Triggers: "list dataflows", "inspect dataflow definition", "dataflow refresh status",
+  "dataflow parameters", "browse dataflows", "dataflow monitoring mcp", "decode mashup".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+
+This skill adds: **how to inspect and monitor Dataflow Gen2 items** using MCP tools (read-only).
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `list_dataflows` | Discover dataflows in a workspace (name, ID, description) |
+| `get_dataflow_definition` | Read M section document — decode base64 mashup.pq |
+| `refresh_dataflow_status` | Poll refresh job status (Completed, Failed, InProgress) |
+
+These are the same tools available in `dataflows-authoring-mcp`. This skill teaches **inspection and monitoring patterns** rather than creation and modification.
+
+## Must / Prefer / Avoid
+
+### MUST
+- Authenticate and discover workspace before any inspection
+- Use `get_dataflow_definition` to read definitions — do not guess M code structure
+
+### PREFER
+- Structured discovery sequence: workspace → dataflows → definition → refresh status
+- Examining queryMetadata.json alongside mashup.pq for full picture
+- Checking refresh status before inspecting definitions (stale definition if refresh in progress)
+
+### AVOID
+- Modifying definitions through consumption tools — use `dataflows-authoring-mcp` for writes
+- Assuming refresh status without polling — always check explicitly
+
+## Discovery Sequence
+
+```text
+1. list_workspaces          → Find target workspace
+2. list_dataflows           → Enumerate dataflows (name, objectId, description)
+3. get_dataflow_definition  → Decode M document + queryMetadata
+4. refresh_dataflow_status  → Check last refresh outcome
+```
+
+## What You Can Learn from Definitions
+
+The `get_dataflow_definition` response contains:
+
+| Component | What It Reveals |
+|-----------|----------------|
+| `mashup.pq` (M code) | Source queries, transforms, destination annotations |
+| `queryMetadata.json` | Connection bindings, staging settings, load status, parameters |
+| `DataDestinations` annotations | Target lakehouse/warehouse, IsNewTarget, update method |
+| `AllowCombine` attribute | Whether multi-source privacy bypass is enabled |
+| `StagingDefinition` | Whether Fast Copy is enabled |
+
+## Refresh Status Interpretation
+
+| Status | Meaning |
+|--------|---------|
+| `Completed` | Refresh succeeded |
+| `Failed` | Refresh failed — check error details |
+| `InProgress` | Still running |
+| `Cancelled` | User or system cancelled |
+| `NotStarted` | Queued but not yet running |
+
+When a refresh fails, the status response includes error details. Common causes:
+- Credentials error → connection binding issue (see CONNECTIONS-CORE.md)
+- M syntax error → definition problem
+- Timeout → query performance issue
+- `DataflowNeverPublishedError` → missing `ApplyChangesIfNeeded` on first refresh

--- a/skills/pipelines-authoring-mcp/SKILL.md
+++ b/skills/pipelines-authoring-mcp/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: pipelines-authoring-mcp
+description: >
+  Create, update, and orchestrate Fabric Data Pipelines using MCP tools. Uses data-factory-mcp
+  server tools to create pipelines, define activity chains with dependsOn conditions, configure
+  Dataflow activities within pipelines, set up Cron/Daily/Weekly/Monthly schedules via
+  create_pipeline_schedule, and trigger on-demand runs with run_pipeline. Supports read-modify-
+  write workflows for pipeline JSON definitions including activity parameters, timeout policies,
+  retry configuration, and multi-dataflow orchestration patterns. Use when the user wants to:
+  (1) create a new pipeline via MCP, (2) add or modify pipeline activities, (3) chain dataflow
+  activities with dependencies, (4) schedule pipeline execution, (5) run a pipeline on demand
+  and monitor status, (6) update pipeline definitions programmatically.
+  Triggers: "create pipeline mcp", "pipeline activities", "schedule pipeline", "run pipeline",
+  "pipeline definition", "chain dataflows pipeline", "pipeline dependsOn", "orchestrate
+  dataflows", "pipeline schedule mcp".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+
+This skill adds: **how to create and orchestrate Data Pipelines** using MCP tools.
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `create_pipeline` | Create empty pipeline in a workspace |
+| `update_pipeline` | Update pipeline metadata (name, description) |
+| `update_pipeline_definition` | Set pipeline JSON (activities, parameters) |
+| `get_pipeline_definition` | Read current pipeline JSON (read-modify-write) |
+| `get_pipeline` | Get pipeline metadata |
+| `list_pipelines` | Discover pipelines in a workspace |
+| `run_pipeline` | Trigger on-demand pipeline execution |
+| `get_pipeline_run_status` | Poll run status until terminal state |
+| `create_pipeline_schedule` | Set up scheduled execution (Cron/Daily/Weekly/Monthly) |
+| `list_pipeline_schedules` | List configured schedules |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Discover the dataflow objectId via `list_dataflows` before referencing in pipeline activities
+- Use `get_pipeline_definition` before `update_pipeline_definition` for read-modify-write
+- Set appropriate timeout policies (default 12h is excessive for dataflow activities)
+
+### PREFER
+- `timeout = "0.01:00:00"` (1h) for Dataflow activities — they rarely need more
+- `retry = 1` with `retryIntervalInSeconds = 60` for transient auth/network failures
+- `dependsOn` with `Succeeded` condition for sequential activity chains
+
+### AVOID
+- Hardcoding dataflow or workspace IDs — always discover via list tools
+- Creating activities without `dependsOn` unless they're truly independent
+
+## Creating a Pipeline with a Dataflow Activity
+
+### Step 1: Discover the dataflow
+
+```text
+list_dataflows(workspaceId="...") → extract objectId
+```
+
+### Step 2: Create the pipeline
+
+```text
+create_pipeline(workspaceId="...", displayName="Monthly Refresh", description="...")
+→ returns pipelineId
+```
+
+### Step 3: Set the definition
+
+```text
+update_pipeline_definition(workspaceId="...", pipelineId="...", definitionJson="...")
+```
+
+Use `templates/pipeline-single-dataflow.json` for the complete JSON structure. Replace `ACTIVITY_NAME`, `DATAFLOW_ID`, `WORKSPACE_ID`.
+
+### Step 4: Schedule (optional)
+
+```text
+create_pipeline_schedule(workspaceId="...", pipelineId="...", ...)
+```
+
+Supports Cron, Daily, Weekly, and Monthly frequency.
+
+### Step 5: Run on demand (optional)
+
+```text
+run_pipeline(workspaceId="...", pipelineId="...")
+→ returns runId
+get_pipeline_run_status(workspaceId="...", pipelineId="...", runId="...")
+→ poll until Completed/Failed
+```
+
+## Chaining Activities
+
+Use `dependsOn` to sequence activities:
+
+```json
+{
+  "name": "RefreshAggregations",
+  "type": "DataflowActivity",
+  "dependsOn": [
+    {
+      "activity": "RefreshSources",
+      "dependencyConditions": ["Succeeded"]
+    }
+  ]
+}
+```
+
+Dependency conditions: `Succeeded`, `Failed`, `Skipped`, `Completed` (any outcome).
+
+## Policy Settings
+
+| Setting | Default | Recommended |
+|---------|---------|-------------|
+| `timeout` | `0.12:00:00` (12h) | `0.01:00:00` (1h) for dataflows |
+| `retry` | 0 | 1 for transient failures |
+| `retryIntervalInSeconds` | 30 | 60 for token refresh timing |
+
+## Debugging Failed Activities
+
+Pipeline runs surface activity-level status. When a Dataflow activity fails:
+1. Check `refresh_dataflow_status` for the underlying dataflow error
+2. The pipeline shows "Failed" but the root cause is always in the dataflow refresh
+3. Common causes: expired connection (re-bind), M syntax error, timeout (chunk query)
+
+## Supplementary References
+
+| Reference | When |
+|-----------|------|
+| `references/activity-patterns.md` | Complex chaining, multi-dataflow orchestration |

--- a/skills/pipelines-authoring-mcp/references/activity-patterns.md
+++ b/skills/pipelines-authoring-mcp/references/activity-patterns.md
@@ -1,0 +1,95 @@
+# Data Factory Pipelines
+
+## MCP Tools
+
+- `create_pipeline` → create empty pipeline in a workspace
+- `update_pipeline_definition` → set the pipeline JSON (activities, schedule)
+- `get_pipeline_definition` → read current pipeline JSON
+- `get_pipeline` → get pipeline metadata (name, description)
+- `update_pipeline` → update pipeline metadata
+- `list_pipelines` → list all pipelines in a workspace
+
+## Creating a Pipeline with a Dataflow Activity
+
+### Step 0: Discover the dataflow ID
+
+```python
+list_dataflows(workspaceId="...")
+# Returns array with objectId, name, description for each dataflow
+# Use objectId as the DATAFLOW_ID in pipeline definitions
+```
+
+### Step 1: Create the pipeline
+
+```python
+create_pipeline(
+  workspaceId="...",
+  displayName="Monthly Refresh",
+  description="Refreshes the store performance dataflow monthly"
+)
+# Returns pipelineId
+```
+
+### Step 2: Set the definition with a Dataflow activity
+
+```python
+update_pipeline_definition(
+  workspaceId="...",
+  pipelineId="...",
+  definitionJson="""{ ... }"""  # See templates below
+)
+```
+
+Use `templates/pipeline-single-dataflow.json` for the complete JSON structure. Replace `ACTIVITY_NAME`, `DATAFLOW_ID`, `WORKSPACE_ID`.
+
+### Chaining Activities
+
+Use `dependsOn` to sequence activities. Use `templates/pipeline-chained-dataflows.json` for a 3-activity chain template.
+
+Dependency conditions: `Succeeded`, `Failed`, `Skipped`, `Completed` (any outcome).
+
+## Scheduling
+
+Pipeline schedules cannot be set via the MCP API. After creating the pipeline, the user must configure the schedule in Fabric Studio:
+
+1. Open pipeline in the workspace
+2. Click **Schedule** on the toolbar
+3. Set frequency (hourly, daily, weekly, monthly)
+
+Always inform the user of this manual step after creating a pipeline.
+
+## Common Pipeline Patterns
+
+### Single Dataflow Refresh
+One activity, one dataflow. Use for simple monthly/weekly refresh of a reporting dataflow.
+
+### Multi-Dataflow Chain
+Sequence multiple dataflows when downstream depends on upstream:
+```
+Refresh Sources → Refresh Aggregations → Refresh Reports
+```
+Each activity depends on the previous with `Succeeded` condition.
+
+### Debugging Failed Activities
+
+Pipeline runs surface activity-level status. When a Dataflow activity fails:
+1. Check `refresh_dataflow_status` for the underlying dataflow error (credentials, M syntax, timeout)
+2. The pipeline shows "Failed" but the root cause is always in the dataflow refresh status
+3. Common causes: expired connection (re-bind), M syntax error (fix via `save_dataflow_definition`), timeout (chunk the query)
+
+### Policy Settings
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `timeout` | `0.12:00:00` (12h) | Use `0.01:00:00` (1h) for dataflows; they rarely need more |
+| `retry` | 0 | Set to 1 for transient auth/network failures |
+| `retryIntervalInSeconds` | 30 | 60s is safer for token refresh timing |
+
+### Template Field Notes
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `dataflowId` | Yes | From `list_dataflows` → `objectId` |
+| `workspaceId` | Yes | Workspace containing the dataflow |
+| `lastModifiedByObjectId` | No | Set to zeros; platform overwrites on save |
+| `lastPublishTime` | No | Set to any date; platform overwrites on save |

--- a/skills/pipelines-consumption-mcp/SKILL.md
+++ b/skills/pipelines-consumption-mcp/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pipelines-consumption-mcp
+description: >
+  Inspect and monitor Fabric Data Pipelines using MCP tools for read-only exploration and run
+  tracking. Uses data-factory-mcp server tools to list pipelines across workspaces, decode base64
+  pipeline JSON definitions to examine activity configurations and dependency chains, poll run
+  status for on-demand and scheduled executions (NotStarted, InProgress, Completed, Failed,
+  Cancelled, Deduped), and list configured schedules. Provides structured discovery: list
+  workspaces, enumerate pipelines, inspect metadata and definitions, check run history and
+  schedule configuration. Use when the user wants to: (1) browse pipelines in a workspace,
+  (2) inspect activity definitions without modifying, (3) check pipeline run status or failure
+  reasons, (4) list pipeline schedules, (5) audit pipeline configurations,
+  (6) understand activity dependencies in a pipeline.
+  Triggers: "list pipelines", "pipeline run status", "inspect pipeline definition",
+  "pipeline schedules", "browse pipelines mcp", "pipeline monitoring".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used, check for data-factory-mcp updates.
+
+## Prerequisite Knowledge
+
+Read these companion documents:
+- [DATAFACTORY-MCP-CORE.md](../../common/DATAFACTORY-MCP-CORE.md) — Authentication, workspace discovery, MCP patterns
+
+This skill adds: **how to inspect and monitor Data Pipelines** using MCP tools (read-only).
+
+## MCP Tools (this skill)
+
+| Tool | Purpose |
+|------|---------|
+| `list_pipelines` | Discover pipelines in a workspace |
+| `get_pipeline` | Read pipeline metadata (name, description) |
+| `get_pipeline_definition` | Read pipeline JSON definition (activities, parameters) |
+| `get_pipeline_run_status` | Poll run status |
+| `list_pipeline_schedules` | List configured schedules |
+
+## Must / Prefer / Avoid
+
+### MUST
+- Authenticate and discover workspace before inspection
+- Use `get_pipeline_definition` to read definitions — do not guess activity structure
+
+### PREFER
+- Discovery sequence: workspace → pipelines → definition → run status
+- Checking run status before inspecting definitions (stale if run in progress)
+- Reading schedule configuration alongside run history for full operational picture
+
+### AVOID
+- Modifying definitions — use `pipelines-authoring-mcp` for writes
+- Assuming run status without polling
+
+## Discovery Sequence
+
+```text
+1. list_workspaces            → Find target workspace
+2. list_pipelines             → Enumerate pipelines
+3. get_pipeline               → Read metadata
+4. get_pipeline_definition    → Decode activity configuration
+5. get_pipeline_run_status    → Check last run outcome
+6. list_pipeline_schedules    → See configured schedules
+```
+
+## Run Status Interpretation
+
+| Status | Meaning |
+|--------|---------|
+| `Completed` | All activities succeeded |
+| `Failed` | One or more activities failed — check activity-level details |
+| `InProgress` | Still running |
+| `Cancelled` | User or system cancelled |
+| `NotStarted` | Queued but not yet running |
+| `Deduped` | Skipped because another run was already in progress |
+
+When a run fails, dig into the underlying item:
+- Dataflow activity failure → check `refresh_dataflow_status` for the dataflow error
+- Copy Job activity failure → check Copy Job run status


### PR DESCRIPTION
decompose monolithic skill into fabricskills-standard  Item-centric skills

Restructure claude-skills/ into 8 item-centric skills following the fabricskills v0.3.0 standard with YAML frontmatter, Must/Prefer/Avoid sections, and progressive disclosure.

Skills (8 new):
- dataflows-authoring-mcp / dataflows-consumption-mcp
- pipelines-authoring-mcp / pipelines-consumption-mcp
- copyjobs-authoring-mcp / copyjobs-consumption-mcp
- connections-authoring-mcp
- datafactory-operations-mcp (cross-item diagnostics)

Shared knowledge (2 new):
- common/DATAFACTORY-MCP-CORE.md (auth, workspace, MCP patterns)
- common/CONNECTIONS-CORE.md (connection model, binding lifecycle)

Routing:
- agents/DataFactoryEngineer.agent.md with delegation rules
- SEP-2640 skill:// resource handler (SkillResourceHandler.cs + SkillRegistry.cs)
- Registered in all 3 hosts (stdio, HTTP, Windows)

Evals (+31 new, 145 total):
- pipelines.eval.md: +8 evals (run, status, schedule)
- copyjobs.eval.md: 15 new evals (full CRUD + run + schedule)
- operations.eval.md: 8 new evals (cross-item triage) 46)

Fixes:
- Pipeline scheduling docs corrected (was falsely stating manual-only)
- Copy Job skill coverage added (was zero)