### PR TITLE
feat: add Apache Airflow Job MCP tools for Microsoft Fabric

### DIFF
--- a/DataFactory.MCP.Core/Abstractions/Interfaces/IFabricAirflowJobService.cs
+++ b/DataFactory.MCP.Core/Abstractions/Interfaces/IFabricAirflowJobService.cs
@@ -1,0 +1,64 @@
+using DataFactory.MCP.Models.AirflowJob;
+using DataFactory.MCP.Models.AirflowJob.Definition;
+
+namespace DataFactory.MCP.Abstractions.Interfaces;
+
+/// <summary>
+/// Service for interacting with Microsoft Fabric Apache Airflow Jobs API
+/// </summary>
+public interface IFabricAirflowJobService
+{
+    /// <summary>
+    /// Lists all Apache Airflow Jobs from the specified workspace
+    /// </summary>
+    Task<ListAirflowJobsResponse> ListAirflowJobsAsync(
+        string workspaceId,
+        string? continuationToken = null);
+
+    /// <summary>
+    /// Creates a new Apache Airflow Job in the specified workspace
+    /// </summary>
+    Task<AirflowJob> CreateAirflowJobAsync(
+        string workspaceId,
+        CreateAirflowJobRequest request);
+
+    /// <summary>
+    /// Gets Apache Airflow Job metadata by ID
+    /// </summary>
+    Task<AirflowJob> GetAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId);
+
+    /// <summary>
+    /// Updates Apache Airflow Job metadata (displayName, description)
+    /// </summary>
+    Task<AirflowJob> UpdateAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId,
+        UpdateAirflowJobRequest request);
+
+    /// <summary>
+    /// Deletes an Apache Airflow Job
+    /// </summary>
+    Task DeleteAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId,
+        bool hardDelete = false);
+
+    /// <summary>
+    /// Gets the definition of an Apache Airflow Job
+    /// </summary>
+    Task<AirflowJobDefinition> GetAirflowJobDefinitionAsync(
+        string workspaceId,
+        string airflowJobId,
+        string? format = null);
+
+    /// <summary>
+    /// Updates the definition of an Apache Airflow Job
+    /// </summary>
+    Task UpdateAirflowJobDefinitionAsync(
+        string workspaceId,
+        string airflowJobId,
+        AirflowJobDefinition definition,
+        bool updateMetadata = false);
+}

--- a/DataFactory.MCP.Core/Extensions/AirflowJobExtensions.cs
+++ b/DataFactory.MCP.Core/Extensions/AirflowJobExtensions.cs
@@ -1,0 +1,25 @@
+using DataFactory.MCP.Models.AirflowJob;
+
+namespace DataFactory.MCP.Extensions;
+
+/// <summary>
+/// Extension methods for Apache Airflow Job model transformations.
+/// </summary>
+public static class AirflowJobExtensions
+{
+    /// <summary>
+    /// Formats an AirflowJob object for MCP API responses.
+    /// </summary>
+    public static object ToFormattedInfo(this AirflowJob airflowJob)
+    {
+        return new
+        {
+            Id = airflowJob.Id,
+            DisplayName = airflowJob.DisplayName,
+            Description = airflowJob.Description,
+            Type = airflowJob.Type,
+            WorkspaceId = airflowJob.WorkspaceId,
+            FolderId = airflowJob.FolderId
+        };
+    }
+}

--- a/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using DataFactory.MCP.Services.DMTSv2;
 using DataFactory.MCP.Services.Notifications;
 using DataFactory.MCP.Tools;
 using DataFactory.MCP.Tools.Dataflow;
+using DataFactory.MCP.Tools.AirflowJob;
 using DataFactory.MCP.Tools.CopyJob;
 using DataFactory.MCP.Tools.Pipeline;
 
@@ -69,6 +70,8 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IFabricPipelineService, FabricPipelineService>()
             // Copy Job service
             .AddSingleton<IFabricCopyJobService, FabricCopyJobService>()
+            // Apache Airflow Job service
+            .AddSingleton<IFabricAirflowJobService, FabricAirflowJobService>()
             // Session accessor for background notifications
             .AddSingleton<IMcpSessionAccessor, McpSessionAccessor>()
             // Background task system (consolidated: monitor handles start, track, poll, notify)
@@ -100,6 +103,7 @@ public static class ServiceCollectionExtensions
             .WithTools<DataflowDefinitionTool>()
             .WithTools<PipelineTool>()
             .WithTools<CopyJobTool>()
+            .WithTools<AirflowJobTool>()
             .WithTools<CreateConnectionUITool>()                // MCP Apps: Create Connection UI
             .WithResources<CreateConnectionResourceHandler>();  // MCP Apps: Create Connection Resource
     }

--- a/DataFactory.MCP.Core/Models/AirflowJob/AirflowJob.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/AirflowJob.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob;
+
+/// <summary>
+/// Represents an Apache Airflow Job item in Microsoft Fabric
+/// </summary>
+public class AirflowJob
+{
+    /// <summary>
+    /// The item ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item display name
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item description
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The item type
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The workspace ID
+    /// </summary>
+    [JsonPropertyName("workspaceId")]
+    public string WorkspaceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The folder ID
+    /// </summary>
+    [JsonPropertyName("folderId")]
+    public string? FolderId { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/CreateAirflowJobRequest.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/CreateAirflowJobRequest.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob;
+
+/// <summary>
+/// Create Apache Airflow Job request payload
+/// </summary>
+public class CreateAirflowJobRequest
+{
+    /// <summary>
+    /// The Apache Airflow Job display name. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [Required(ErrorMessage = "Display name is required")]
+    [StringLength(256, ErrorMessage = "Display name cannot exceed 256 characters")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Apache Airflow Job description. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [StringLength(256, ErrorMessage = "Description cannot exceed 256 characters")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The folder ID. If not specified or null, the item is created with the workspace as its folder.
+    /// </summary>
+    [JsonPropertyName("folderId")]
+    public string? FolderId { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/Definition/AirflowJobDefinition.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/Definition/AirflowJobDefinition.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob.Definition;
+
+/// <summary>
+/// Apache Airflow Job public definition object
+/// </summary>
+public class AirflowJobDefinition
+{
+    /// <summary>
+    /// The definition format. Optional — used when requesting a specific format.
+    /// </summary>
+    [JsonPropertyName("format")]
+    public string? Format { get; set; }
+
+    /// <summary>
+    /// A list of definition parts
+    /// </summary>
+    [JsonPropertyName("parts")]
+    [Required(ErrorMessage = "Definition parts are required")]
+    public List<AirflowJobDefinitionPart> Parts { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/Definition/AirflowJobDefinitionPart.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/Definition/AirflowJobDefinitionPart.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob.Definition;
+
+/// <summary>
+/// Apache Airflow Job definition part object
+/// </summary>
+public class AirflowJobDefinitionPart
+{
+    /// <summary>
+    /// The definition part path
+    /// </summary>
+    [JsonPropertyName("path")]
+    [Required(ErrorMessage = "Path is required")]
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The definition part payload (base64 encoded)
+    /// </summary>
+    [JsonPropertyName("payload")]
+    [Required(ErrorMessage = "Payload is required")]
+    public string Payload { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The payload type
+    /// </summary>
+    [JsonPropertyName("payloadType")]
+    public string PayloadType { get; set; } = "InlineBase64";
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/Definition/GetAirflowJobDefinitionResponse.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/Definition/GetAirflowJobDefinitionResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob.Definition;
+
+/// <summary>
+/// Internal class for HTTP response deserialization when fetching Airflow Job definitions
+/// </summary>
+internal sealed class GetAirflowJobDefinitionResponse
+{
+    [JsonPropertyName("definition")]
+    public AirflowJobDefinition Definition { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/Definition/UpdateAirflowJobDefinitionRequest.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/Definition/UpdateAirflowJobDefinitionRequest.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob.Definition;
+
+/// <summary>
+/// Request model for updating an Apache Airflow Job definition
+/// </summary>
+public class UpdateAirflowJobDefinitionRequest
+{
+    /// <summary>
+    /// The definition to update
+    /// </summary>
+    [JsonPropertyName("definition")]
+    public AirflowJobDefinition Definition { get; set; } = new();
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/ListAirflowJobsResponse.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/ListAirflowJobsResponse.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob;
+
+/// <summary>
+/// Response model for listing Apache Airflow Jobs
+/// </summary>
+public class ListAirflowJobsResponse
+{
+    /// <summary>
+    /// A list of Apache Airflow Jobs
+    /// </summary>
+    [JsonPropertyName("value")]
+    public List<AirflowJob> Value { get; set; } = new();
+
+    /// <summary>
+    /// The token for the next result set batch. If there are no more records, it's removed from the response.
+    /// </summary>
+    [JsonPropertyName("continuationToken")]
+    public string? ContinuationToken { get; set; }
+
+    /// <summary>
+    /// The URI of the next result set batch. If there are no more records, it's removed from the response.
+    /// </summary>
+    [JsonPropertyName("continuationUri")]
+    public string? ContinuationUri { get; set; }
+}

--- a/DataFactory.MCP.Core/Models/AirflowJob/UpdateAirflowJobRequest.cs
+++ b/DataFactory.MCP.Core/Models/AirflowJob/UpdateAirflowJobRequest.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace DataFactory.MCP.Models.AirflowJob;
+
+/// <summary>
+/// Update Apache Airflow Job request payload
+/// </summary>
+public class UpdateAirflowJobRequest
+{
+    /// <summary>
+    /// The Apache Airflow Job display name. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [StringLength(256, ErrorMessage = "Display name cannot exceed 256 characters")]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The Apache Airflow Job description. Maximum length is 256 characters.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [StringLength(256, ErrorMessage = "Description cannot exceed 256 characters")]
+    public string? Description { get; set; }
+}

--- a/DataFactory.MCP.Core/Services/FabricAirflowJobService.cs
+++ b/DataFactory.MCP.Core/Services/FabricAirflowJobService.cs
@@ -1,0 +1,239 @@
+using DataFactory.MCP.Abstractions;
+using DataFactory.MCP.Abstractions.Interfaces;
+using DataFactory.MCP.Extensions;
+using DataFactory.MCP.Infrastructure.Http;
+using DataFactory.MCP.Models.AirflowJob;
+using DataFactory.MCP.Models.AirflowJob.Definition;
+using Microsoft.Extensions.Logging;
+
+namespace DataFactory.MCP.Services;
+
+/// <summary>
+/// Service for interacting with Microsoft Fabric Apache Airflow Jobs API
+/// </summary>
+public class FabricAirflowJobService : FabricServiceBase, IFabricAirflowJobService
+{
+    public FabricAirflowJobService(
+        IHttpClientFactory httpClientFactory,
+        ILogger<FabricAirflowJobService> logger,
+        IValidationService validationService)
+        : base(httpClientFactory, logger, validationService)
+    {
+    }
+
+    public async Task<ListAirflowJobsResponse> ListAirflowJobsAsync(
+        string workspaceId,
+        string? continuationToken = null)
+    {
+        try
+        {
+            ValidateGuids((workspaceId, nameof(workspaceId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs")
+                .BuildEndpoint();
+            Logger.LogInformation("Fetching Apache Airflow Jobs from workspace {WorkspaceId}", workspaceId);
+
+            var response = await GetAsync<ListAirflowJobsResponse>(endpoint, continuationToken);
+
+            Logger.LogInformation("Successfully retrieved {Count} Apache Airflow Jobs from workspace {WorkspaceId}",
+                response?.Value?.Count ?? 0, workspaceId);
+            return response ?? new ListAirflowJobsResponse();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching Apache Airflow Jobs from workspace {WorkspaceId}", workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<AirflowJob> CreateAirflowJobAsync(
+        string workspaceId,
+        CreateAirflowJobRequest request)
+    {
+        try
+        {
+            ValidateGuids((workspaceId, nameof(workspaceId)));
+            ValidationService.ValidateAndThrow(request, nameof(request));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs")
+                .BuildEndpoint();
+            Logger.LogInformation("Creating Apache Airflow Job '{DisplayName}' in workspace {WorkspaceId}",
+                request.DisplayName, workspaceId);
+
+            var created = await PostAsync<AirflowJob>(endpoint, request);
+
+            Logger.LogInformation("Successfully created Apache Airflow Job '{DisplayName}' with ID {AirflowJobId} in workspace {WorkspaceId}",
+                request.DisplayName, created?.Id, workspaceId);
+
+            return created ?? new AirflowJob();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error creating Apache Airflow Job '{DisplayName}' in workspace {WorkspaceId}",
+                request?.DisplayName, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<AirflowJob> GetAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (airflowJobId, nameof(airflowJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs/{airflowJobId}")
+                .BuildEndpoint();
+            Logger.LogInformation("Fetching Apache Airflow Job {AirflowJobId} from workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+
+            var airflowJob = await GetAsync<AirflowJob>(endpoint);
+
+            Logger.LogInformation("Successfully retrieved Apache Airflow Job {AirflowJobId}", airflowJobId);
+            return airflowJob ?? throw new InvalidOperationException($"Apache Airflow Job {airflowJobId} not found");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching Apache Airflow Job {AirflowJobId} from workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<AirflowJob> UpdateAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId,
+        UpdateAirflowJobRequest request)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (airflowJobId, nameof(airflowJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs/{airflowJobId}")
+                .BuildEndpoint();
+            Logger.LogInformation("Updating Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+
+            var updated = await PatchAsync<AirflowJob>(endpoint, request);
+
+            Logger.LogInformation("Successfully updated Apache Airflow Job {AirflowJobId}", airflowJobId);
+            return updated ?? throw new InvalidOperationException($"Failed to update Apache Airflow Job {airflowJobId}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task DeleteAirflowJobAsync(
+        string workspaceId,
+        string airflowJobId,
+        bool hardDelete = false)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (airflowJobId, nameof(airflowJobId)));
+
+            var url = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs/{airflowJobId}")
+                .WithQueryParam("hardDelete", hardDelete ? (bool?)true : null)
+                .Build();
+            Logger.LogInformation("Deleting Apache Airflow Job {AirflowJobId} from workspace {WorkspaceId} (hardDelete={HardDelete})",
+                airflowJobId, workspaceId, hardDelete);
+
+            var response = await HttpClient.DeleteAsync(url);
+            await response.EnsureSuccessOrThrowAsync();
+
+            Logger.LogInformation("Successfully deleted Apache Airflow Job {AirflowJobId}", airflowJobId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error deleting Apache Airflow Job {AirflowJobId} from workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task<AirflowJobDefinition> GetAirflowJobDefinitionAsync(
+        string workspaceId,
+        string airflowJobId,
+        string? format = null)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (airflowJobId, nameof(airflowJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs/{airflowJobId}/getDefinition")
+                .WithQueryParam("format", format)
+                .BuildEndpoint();
+            Logger.LogInformation("Getting definition for Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+
+            var emptyRequest = new { };
+            var response = await PostAsync<GetAirflowJobDefinitionResponse>(endpoint, emptyRequest)
+                           ?? throw new InvalidOperationException("Failed to get Apache Airflow Job definition response");
+
+            Logger.LogInformation("Successfully retrieved definition for Apache Airflow Job {AirflowJobId}", airflowJobId);
+            return response.Definition;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error getting definition for Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+            throw;
+        }
+    }
+
+    public async Task UpdateAirflowJobDefinitionAsync(
+        string workspaceId,
+        string airflowJobId,
+        AirflowJobDefinition definition,
+        bool updateMetadata = false)
+    {
+        try
+        {
+            ValidateGuids(
+                (workspaceId, nameof(workspaceId)),
+                (airflowJobId, nameof(airflowJobId)));
+
+            var endpoint = FabricUrlBuilder.ForFabricApi()
+                .WithLiteralPath($"workspaces/{workspaceId}/apacheAirflowJobs/{airflowJobId}/updateDefinition")
+                .WithQueryParam("updateMetadata", updateMetadata ? (bool?)true : null)
+                .BuildEndpoint();
+            Logger.LogInformation("Updating definition for Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+
+            var request = new UpdateAirflowJobDefinitionRequest { Definition = definition };
+            var success = await PostNoContentAsync(endpoint, request);
+
+            if (!success)
+            {
+                throw new HttpRequestException($"Failed to update definition for Apache Airflow Job {airflowJobId}");
+            }
+
+            Logger.LogInformation("Successfully updated definition for Apache Airflow Job {AirflowJobId}", airflowJobId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error updating definition for Apache Airflow Job {AirflowJobId} in workspace {WorkspaceId}",
+                airflowJobId, workspaceId);
+            throw;
+        }
+    }
+}

--- a/DataFactory.MCP.Core/Tools/AirflowJob/AirflowJobTool.cs
+++ b/DataFactory.MCP.Core/Tools/AirflowJob/AirflowJobTool.cs
@@ -1,0 +1,391 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
+using DataFactory.MCP.Abstractions.Interfaces;
+using DataFactory.MCP.Extensions;
+using DataFactory.MCP.Models.AirflowJob;
+using DataFactory.MCP.Models.AirflowJob.Definition;
+
+namespace DataFactory.MCP.Tools.AirflowJob;
+
+/// <summary>
+/// MCP Tool for managing Microsoft Fabric Apache Airflow Jobs.
+/// Handles CRUD operations and definition management.
+/// </summary>
+[McpServerToolType]
+public class AirflowJobTool
+{
+    private readonly IFabricAirflowJobService _airflowJobService;
+    private readonly IValidationService _validationService;
+
+    public AirflowJobTool(
+        IFabricAirflowJobService airflowJobService,
+        IValidationService validationService)
+    {
+        _airflowJobService = airflowJobService;
+        _validationService = validationService;
+    }
+
+    [McpServerTool, Description(@"Returns a list of Apache Airflow Jobs from the specified workspace. This API supports pagination.")]
+    public async Task<string> ListAirflowJobsAsync(
+        [Description("The workspace ID to list Apache Airflow Jobs from (required)")] string workspaceId,
+        [Description("A token for retrieving the next page of results (optional)")] string? continuationToken = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+
+            var response = await _airflowJobService.ListAirflowJobsAsync(workspaceId, continuationToken);
+
+            if (!response.Value.Any())
+            {
+                return $"No Apache Airflow Jobs found in workspace '{workspaceId}'.";
+            }
+
+            var result = new
+            {
+                WorkspaceId = workspaceId,
+                AirflowJobCount = response.Value.Count,
+                ContinuationToken = response.ContinuationToken,
+                ContinuationUri = response.ContinuationUri,
+                HasMoreResults = !string.IsNullOrEmpty(response.ContinuationToken),
+                AirflowJobs = response.Value.Select(j => j.ToFormattedInfo())
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("listing Apache Airflow Jobs").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Creates an Apache Airflow Job in the specified workspace.")]
+    public async Task<string> CreateAirflowJobAsync(
+        [Description("The workspace ID where the Apache Airflow Job will be created (required)")] string workspaceId,
+        [Description("The Apache Airflow Job display name (required)")] string displayName,
+        [Description("The Apache Airflow Job description (optional, max 256 characters)")] string? description = null,
+        [Description("The folder ID where the job will be created (optional, defaults to workspace root)")] string? folderId = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(displayName, nameof(displayName));
+
+            var request = new CreateAirflowJobRequest
+            {
+                DisplayName = displayName,
+                Description = description,
+                FolderId = folderId
+            };
+
+            var created = await _airflowJobService.CreateAirflowJobAsync(workspaceId, request);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Apache Airflow Job '{displayName}' created successfully",
+                AirflowJobId = created.Id,
+                DisplayName = created.DisplayName,
+                Description = created.Description,
+                Type = created.Type,
+                WorkspaceId = created.WorkspaceId,
+                FolderId = created.FolderId,
+                CreatedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("creating Apache Airflow Job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Gets the metadata of an Apache Airflow Job by ID.")]
+    public async Task<string> GetAirflowJobAsync(
+        [Description("The workspace ID containing the Apache Airflow Job (required)")] string workspaceId,
+        [Description("The Apache Airflow Job ID to retrieve (required)")] string airflowJobId)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(airflowJobId, nameof(airflowJobId));
+
+            var airflowJob = await _airflowJobService.GetAirflowJobAsync(workspaceId, airflowJobId);
+
+            return airflowJob.ToFormattedInfo().ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("getting Apache Airflow Job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Updates the metadata (displayName and/or description) of an Apache Airflow Job.")]
+    public async Task<string> UpdateAirflowJobAsync(
+        [Description("The workspace ID containing the Apache Airflow Job (required)")] string workspaceId,
+        [Description("The Apache Airflow Job ID to update (required)")] string airflowJobId,
+        [Description("The new display name (optional)")] string? displayName = null,
+        [Description("The new description (optional)")] string? description = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(airflowJobId, nameof(airflowJobId));
+
+            if (string.IsNullOrEmpty(displayName) && description == null)
+            {
+                throw new ArgumentException("At least one of displayName or description must be provided");
+            }
+
+            var request = new UpdateAirflowJobRequest
+            {
+                DisplayName = displayName,
+                Description = description
+            };
+
+            var updated = await _airflowJobService.UpdateAirflowJobAsync(workspaceId, airflowJobId, request);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Apache Airflow Job '{updated.DisplayName}' updated successfully",
+                AirflowJob = updated.ToFormattedInfo()
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("updating Apache Airflow Job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Deletes an Apache Airflow Job. Use hardDelete=true to permanently delete the item, bypassing the recycle bin.")]
+    public async Task<string> DeleteAirflowJobAsync(
+        [Description("The workspace ID containing the Apache Airflow Job (required)")] string workspaceId,
+        [Description("The Apache Airflow Job ID to delete (required)")] string airflowJobId,
+        [Description("When true, permanently deletes the item without going through the recycle bin (optional, default false)")] bool hardDelete = false)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(airflowJobId, nameof(airflowJobId));
+
+            await _airflowJobService.DeleteAirflowJobAsync(workspaceId, airflowJobId, hardDelete);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Apache Airflow Job '{airflowJobId}' deleted successfully",
+                AirflowJobId = airflowJobId,
+                WorkspaceId = workspaceId,
+                HardDelete = hardDelete
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("deleting Apache Airflow Job").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Gets the definition of an Apache Airflow Job. The definition contains the job configuration with base64-encoded parts.")]
+    public async Task<string> GetAirflowJobDefinitionAsync(
+        [Description("The workspace ID containing the Apache Airflow Job (required)")] string workspaceId,
+        [Description("The Apache Airflow Job ID to get the definition for (required)")] string airflowJobId,
+        [Description("The definition format to return (optional)")] string? format = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(airflowJobId, nameof(airflowJobId));
+
+            var definition = await _airflowJobService.GetAirflowJobDefinitionAsync(workspaceId, airflowJobId, format);
+
+            var result = new
+            {
+                Success = true,
+                AirflowJobId = airflowJobId,
+                WorkspaceId = workspaceId,
+                Format = definition.Format,
+                PartsCount = definition.Parts.Count,
+                Parts = definition.Parts.Select(p => new
+                {
+                    Path = p.Path,
+                    PayloadType = p.PayloadType,
+                    DecodedPayload = TryDecodeBase64(p.Payload)
+                })
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("getting Apache Airflow Job definition").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Updates the definition of an Apache Airflow Job with the provided JSON content. The JSON will be base64-encoded and sent to the API.")]
+    public async Task<string> UpdateAirflowJobDefinitionAsync(
+        [Description("The workspace ID containing the Apache Airflow Job (required)")] string workspaceId,
+        [Description("The Apache Airflow Job ID to update (required)")] string airflowJobId,
+        [Description("The Airflow Job definition JSON content (required)")] string definitionJson,
+        [Description("When true, updates the item's metadata (e.g. sensitivity label) as part of the definition update (optional, default false)")] bool updateMetadata = false)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(airflowJobId, nameof(airflowJobId));
+            _validationService.ValidateRequiredString(definitionJson, nameof(definitionJson));
+
+            // Validate JSON format
+            try
+            {
+                JsonDocument.Parse(definitionJson);
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException($"Invalid JSON format: {ex.Message}");
+            }
+
+            // Encode the JSON as base64
+            var base64Payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(definitionJson));
+
+            var definition = new AirflowJobDefinition
+            {
+                Parts = new List<AirflowJobDefinitionPart>
+                {
+                    new AirflowJobDefinitionPart
+                    {
+                        Path = "airflowjob-content.json",
+                        Payload = base64Payload,
+                        PayloadType = "InlineBase64"
+                    }
+                }
+            };
+
+            await _airflowJobService.UpdateAirflowJobDefinitionAsync(workspaceId, airflowJobId, definition, updateMetadata);
+
+            var result = new
+            {
+                Success = true,
+                AirflowJobId = airflowJobId,
+                WorkspaceId = workspaceId,
+                UpdateMetadata = updateMetadata,
+                Message = "Apache Airflow Job definition updated successfully"
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("updating Apache Airflow Job definition").ToMcpJson();
+        }
+    }
+
+    private static string TryDecodeBase64(string? payload)
+    {
+        if (string.IsNullOrEmpty(payload))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var bytes = Convert.FromBase64String(payload);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch
+        {
+            return payload;
+        }
+    }
+}

--- a/DataFactory.MCP.Tests/Infrastructure/McpTestFixture.cs
+++ b/DataFactory.MCP.Tests/Infrastructure/McpTestFixture.cs
@@ -13,6 +13,7 @@ using DataFactory.MCP.Services.DMTSv2;
 using DataFactory.MCP.Services.Notifications;
 using DataFactory.MCP.Tools;
 using DataFactory.MCP.Tools.Dataflow;
+using DataFactory.MCP.Tools.AirflowJob;
 using DataFactory.MCP.Tools.CopyJob;
 using DataFactory.MCP.Tools.Pipeline;
 
@@ -88,6 +89,7 @@ public class McpTestFixture : IDisposable
                 services.AddScoped<IFabricCapacityService, FabricCapacityService>();
                 services.AddScoped<IFabricPipelineService, FabricPipelineService>();
                 services.AddScoped<IFabricCopyJobService, FabricCopyJobService>();
+                services.AddScoped<IFabricAirflowJobService, FabricAirflowJobService>();
 
                 // Register background task services
                 services.AddSingleton<IMcpSessionAccessor, McpSessionAccessor>();
@@ -107,6 +109,7 @@ public class McpTestFixture : IDisposable
                 services.AddScoped<DataflowDefinitionTool>();
                 services.AddScoped<PipelineTool>();
                 services.AddScoped<CopyJobTool>();
+                services.AddScoped<AirflowJobTool>();
             })
             .Build();
 

--- a/DataFactory.MCP.Tests/Integration/AirflowJobToolIntegrationTests.cs
+++ b/DataFactory.MCP.Tests/Integration/AirflowJobToolIntegrationTests.cs
@@ -1,0 +1,517 @@
+using Xunit;
+using System.Text.Json;
+using DataFactory.MCP.Tools.AirflowJob;
+using DataFactory.MCP.Tests.Infrastructure;
+using DataFactory.MCP.Models;
+
+namespace DataFactory.MCP.Tests.Integration;
+
+/// <summary>
+/// Integration tests for AirflowJobTool that call the actual MCP tool methods
+/// without mocking to verify real behavior
+/// </summary>
+public class AirflowJobToolIntegrationTests : FabricToolIntegrationTestBase
+{
+    private readonly AirflowJobTool _airflowJobTool;
+
+    private const string TestWorkspaceId = "12c5e906-5bfc-4ba4-bd76-c1ce68fc53c8";
+    private const string InvalidWorkspaceId = "invalid-workspace-id";
+    private const string InvalidAirflowJobId = "00000000-0000-0000-0000-000000000001";
+
+    public AirflowJobToolIntegrationTests(McpTestFixture fixture) : base(fixture)
+    {
+        _airflowJobTool = Fixture.GetService<AirflowJobTool>();
+    }
+
+    #region DI Registration
+
+    [Fact]
+    public void AirflowJobTool_ShouldBeRegisteredInDI()
+    {
+        Assert.NotNull(_airflowJobTool);
+        Assert.IsType<AirflowJobTool>(_airflowJobTool);
+    }
+
+    #endregion
+
+    #region ListAirflowJobsAsync - Unauthenticated
+
+    [Fact]
+    public async Task ListAirflowJobsAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.ListAirflowJobsAsync(TestWorkspaceId);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListAirflowJobsAsync_WithContinuationToken_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.ListAirflowJobsAsync(TestWorkspaceId, "test-continuation-token");
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task ListAirflowJobsAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.ListAirflowJobsAsync("");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task ListAirflowJobsAsync_WithNullWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.ListAirflowJobsAsync(null!);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    #endregion
+
+    #region CreateAirflowJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task CreateAirflowJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.CreateAirflowJobAsync(TestWorkspaceId, "test-airflow-job");
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task CreateAirflowJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.CreateAirflowJobAsync("", "test-airflow-job");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task CreateAirflowJobAsync_WithEmptyDisplayName_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.CreateAirflowJobAsync(TestWorkspaceId, "");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("displayName"));
+    }
+
+    [Fact]
+    public async Task CreateAirflowJobAsync_WithNullDisplayName_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.CreateAirflowJobAsync(TestWorkspaceId, null!);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("displayName"));
+    }
+
+    #endregion
+
+    #region GetAirflowJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task GetAirflowJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetAirflowJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobAsync("", InvalidAirflowJobId);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task GetAirflowJobAsync_WithEmptyAirflowJobId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobAsync(TestWorkspaceId, "");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    [Fact]
+    public async Task GetAirflowJobAsync_WithNullAirflowJobId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobAsync(TestWorkspaceId, null!);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    #endregion
+
+    #region UpdateAirflowJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task UpdateAirflowJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId, displayName: "updated");
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobAsync("", InvalidAirflowJobId, displayName: "updated");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobAsync_WithEmptyAirflowJobId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobAsync(TestWorkspaceId, "", displayName: "updated");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobAsync_WithNoUpdates_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        McpResponseAssertHelper.AssertValidationError(result, "At least one of displayName or description must be provided");
+    }
+
+    #endregion
+
+    #region DeleteAirflowJobAsync - Unauthenticated
+
+    [Fact]
+    public async Task DeleteAirflowJobAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.DeleteAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task DeleteAirflowJobAsync_HardDelete_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.DeleteAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId, hardDelete: true);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task DeleteAirflowJobAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.DeleteAirflowJobAsync("", InvalidAirflowJobId);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task DeleteAirflowJobAsync_WithEmptyAirflowJobId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.DeleteAirflowJobAsync(TestWorkspaceId, "");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    #endregion
+
+    #region GetAirflowJobDefinitionAsync - Unauthenticated
+
+    [Fact]
+    public async Task GetAirflowJobDefinitionAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetAirflowJobDefinitionAsync_WithFormat_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId, format: "Default");
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task GetAirflowJobDefinitionAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobDefinitionAsync("", InvalidAirflowJobId);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task GetAirflowJobDefinitionAsync_WithEmptyAirflowJobId_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.GetAirflowJobDefinitionAsync(TestWorkspaceId, "");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    #endregion
+
+    #region UpdateAirflowJobDefinitionAsync - Unauthenticated
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var definitionJson = "{\"schedulerConfig\":{}}";
+
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId, definitionJson);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithUpdateMetadata_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        var definitionJson = "{\"schedulerConfig\":{}}";
+
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId, definitionJson, updateMetadata: true);
+
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        var definitionJson = "{\"schedulerConfig\":{}}";
+
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync("", InvalidAirflowJobId, definitionJson);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithEmptyAirflowJobId_ShouldReturnValidationError()
+    {
+        var definitionJson = "{\"schedulerConfig\":{}}";
+
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync(TestWorkspaceId, "", definitionJson);
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("airflowJobId"));
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithEmptyDefinitionJson_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId, "");
+
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("definitionJson"));
+    }
+
+    [Fact]
+    public async Task UpdateAirflowJobDefinitionAsync_WithInvalidJson_ShouldReturnValidationError()
+    {
+        var result = await _airflowJobTool.UpdateAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId, "not-valid-json{");
+
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid JSON format");
+    }
+
+    #endregion
+
+    #region Authenticated Scenarios
+
+    [SkippableFact]
+    public async Task ListAirflowJobsAsync_WithAuthentication_ShouldReturnResultOrApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _airflowJobTool.ListAirflowJobsAsync(TestWorkspaceId);
+
+        // Assert
+        AssertAirflowJobListResult(result);
+    }
+
+    [SkippableFact]
+    public async Task ListAirflowJobsAsync_WithInvalidWorkspaceId_ShouldReturnApiError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _airflowJobTool.ListAirflowJobsAsync(InvalidWorkspaceId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        AssertNoAuthenticationError(result);
+        Assert.Contains("workspaceId must be a valid GUID", result);
+    }
+
+    [SkippableFact]
+    public async Task GetAirflowJobAsync_WithAuthentication_NonExistentAirflowJob_ShouldReturnError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _airflowJobTool.GetAirflowJobAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+    }
+
+    [SkippableFact]
+    public async Task CreateAirflowJobAsync_WithAuthentication_ShouldCreateSuccessfully()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        var jobName = $"test-airflow-job-{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        // Act
+        var result = await _airflowJobTool.CreateAirflowJobAsync(TestWorkspaceId, jobName, "Created by integration test");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+
+        if (result.Contains("\"success\": true") || result.Contains("created successfully"))
+        {
+            var json = JsonDocument.Parse(result);
+            Assert.True(json.RootElement.TryGetProperty("airflowJobId", out _), "Response should contain airflowJobId");
+            Assert.True(json.RootElement.TryGetProperty("displayName", out _), "Response should contain displayName");
+
+            // Cleanup
+            var airflowJobId = json.RootElement.GetProperty("airflowJobId").GetString();
+            if (!string.IsNullOrEmpty(airflowJobId))
+            {
+                await _airflowJobTool.DeleteAirflowJobAsync(TestWorkspaceId, airflowJobId, hardDelete: true);
+            }
+        }
+    }
+
+    [SkippableFact]
+    public async Task GetAirflowJobDefinitionAsync_WithAuthentication_NonExistentJob_ShouldReturnError()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        // Act
+        var result = await _airflowJobTool.GetAirflowJobDefinitionAsync(TestWorkspaceId, InvalidAirflowJobId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+    }
+
+    [SkippableFact]
+    public async Task AirflowJob_FullLifecycle_CreateGetUpdateDeleteAsync()
+    {
+        // Arrange
+        var isAuthenticated = await TryAuthenticateAsync();
+        Skip.IfNot(isAuthenticated, "Skipping authenticated test - no valid credentials available");
+
+        var jobName = $"test-lifecycle-{DateTime.UtcNow:yyyyMMddHHmmss}";
+        string? airflowJobId = null;
+
+        try
+        {
+            // Step 1: Create
+            var createResult = await _airflowJobTool.CreateAirflowJobAsync(
+                TestWorkspaceId, jobName, "Lifecycle integration test");
+
+            Assert.NotNull(createResult);
+            SkipIfUpstreamBlocked(createResult);
+            AssertNoAuthenticationError(createResult);
+
+            if (!IsValidJson(createResult)) return; // API may not support creation in test workspace
+
+            var createJson = JsonDocument.Parse(createResult);
+            Assert.True(createJson.RootElement.TryGetProperty("airflowJobId", out var idElement),
+                $"Create response missing airflowJobId. Response: {createResult}");
+            airflowJobId = idElement.GetString();
+            Assert.False(string.IsNullOrEmpty(airflowJobId), "airflowJobId should not be empty");
+
+            // Step 2: Get and verify
+            var getResult = await _airflowJobTool.GetAirflowJobAsync(TestWorkspaceId, airflowJobId!);
+            Assert.NotNull(getResult);
+            SkipIfUpstreamBlocked(getResult);
+            AssertNoAuthenticationError(getResult);
+            Assert.True(IsValidJson(getResult), $"Get response should be JSON. Got: {getResult}");
+
+            var getJson = JsonDocument.Parse(getResult);
+            Assert.True(getJson.RootElement.TryGetProperty("id", out _), "Get response should have id");
+            Assert.True(getJson.RootElement.TryGetProperty("displayName", out _), "Get response should have displayName");
+
+            // Step 3: Update metadata
+            var updatedName = $"{jobName}-updated";
+            var updateResult = await _airflowJobTool.UpdateAirflowJobAsync(
+                TestWorkspaceId, airflowJobId!, updatedName, "Updated by lifecycle test");
+
+            Assert.NotNull(updateResult);
+            SkipIfUpstreamBlocked(updateResult);
+            AssertNoAuthenticationError(updateResult);
+
+            // Step 4: List and confirm job appears
+            var listResult = await _airflowJobTool.ListAirflowJobsAsync(TestWorkspaceId);
+            Assert.NotNull(listResult);
+            SkipIfUpstreamBlocked(listResult);
+            AssertNoAuthenticationError(listResult);
+
+            // Step 5: Get definition
+            var definitionResult = await _airflowJobTool.GetAirflowJobDefinitionAsync(TestWorkspaceId, airflowJobId!);
+            Assert.NotNull(definitionResult);
+            SkipIfUpstreamBlocked(definitionResult);
+            AssertNoAuthenticationError(definitionResult);
+        }
+        finally
+        {
+            // Cleanup: always attempt to delete
+            if (!string.IsNullOrEmpty(airflowJobId))
+            {
+                await _airflowJobTool.DeleteAirflowJobAsync(TestWorkspaceId, airflowJobId, hardDelete: true);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static void AssertAirflowJobListResult(string result)
+    {
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+
+        SkipIfUpstreamBlocked(result);
+        AssertNoAuthenticationError(result);
+
+        if (result.Contains("No Apache Airflow Jobs found"))
+        {
+            return; // Valid empty-workspace response
+        }
+
+        if (result.Contains("HttpRequestError"))
+        {
+            McpResponseAssertHelper.AssertHttpError(result);
+            return;
+        }
+
+        if (IsValidJson(result))
+        {
+            var json = JsonDocument.Parse(result);
+            Assert.True(json.RootElement.TryGetProperty("airflowJobCount", out _),
+                "List response should have airflowJobCount");
+            Assert.True(json.RootElement.TryGetProperty("airflowJobs", out _),
+                "List response should have airflowJobs");
+        }
+    }
+
+    #endregion
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Model Context Protocol (MCP) server for Microsoft Fabric resource discovery an
 - **Dataflow Management**: List, create, and retrieve Microsoft Fabric dataflows
 - **Pipeline Management**: List, create, update, run, monitor, and schedule Microsoft Fabric pipelines
 - **Copy Job Management**: List, create, update, run, monitor, and schedule Microsoft Fabric copy jobs
+- **Apache Airflow Job Management**: List, create, update, delete, and manage definitions for Microsoft Fabric Apache Airflow Jobs
 - **Capacity Management**: List and retrieve Microsoft Fabric capacities
 - **Microsoft Fabric Integration**: Support for on-premises, personal, and virtual network gateways
 - 📦 **NuGet Distribution**: Available as a NuGet package for easy integration
@@ -33,6 +34,7 @@ A Model Context Protocol (MCP) server for Microsoft Fabric resource discovery an
 - **Capacity Management**: `list_capacities`
 - **Pipeline Management**: `list_pipelines`, `create_pipeline`, `get_pipeline`, `update_pipeline`, `get_pipeline_definition`, `update_pipeline_definition`, `run_pipeline`, `get_pipeline_run_status`, `create_pipeline_schedule`, `list_pipeline_schedules` *(Preview)*
 - **Copy Job Management**: `list_copy_jobs`, `create_copy_job`, `get_copy_job`, `update_copy_job`, `get_copy_job_definition`, `update_copy_job_definition`, `run_copy_job`, `get_copy_job_run_status`, `create_copy_job_schedule`, `list_copy_job_schedules` *(Preview)*
+- **Apache Airflow Job Management**: `list_airflow_jobs`, `create_airflow_job`, `get_airflow_job`, `update_airflow_job`, `delete_airflow_job`, `get_airflow_job_definition`, `update_airflow_job_definition` *(Preview)*
 
 ## Available Resources
 
@@ -110,6 +112,7 @@ See the detailed guides for comprehensive usage instructions:
 - **Capacity Management**: See [Capacity Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/capacity-management.md)
 - **Pipeline Management**: See [Pipeline Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/pipeline-management.md)
 - **Copy Job Management**: See [Copy Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/copyjob-management.md)
+- **Apache Airflow Job Management**: See [Apache Airflow Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/airflow-job-feature.md)
 
 ## Development
 
@@ -193,6 +196,7 @@ For complete documentation, see our **[Documentation Index](https://github.com/m
 - **[Capacity Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/capacity-management.md)** - Capacity operations and examples
 - **[Pipeline Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/pipeline-management.md)** - Pipeline operations and examples
 - **[Copy Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/copyjob-management.md)** - Copy job operations and examples
+- **[Apache Airflow Job Management Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/airflow-job-feature.md)** - Airflow job operations, definition management, and testing guide
 - **[Architecture Guide](https://github.com/microsoft/DataFactory.MCP/blob/main/docs/ARCHITECTURE.md)** - Technical architecture and design details
 
 ## Contributing

--- a/docs/airflow-job-feature.md
+++ b/docs/airflow-job-feature.md
@@ -1,0 +1,227 @@
+# Apache Airflow Job Support — Feature Summary
+
+## What Was Built
+
+Full MCP tool support for **Microsoft Fabric Apache Airflow Jobs** was added to DataFactory.MCP. This follows the existing 3-layer architecture (Tool → Service → Model) and exposes 7 new MCP tools.
+
+### New MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_airflow_jobs` | List all Airflow Jobs in a workspace (paginated) |
+| `create_airflow_job` | Create a new Airflow Job |
+| `get_airflow_job` | Get metadata for a specific Airflow Job |
+| `update_airflow_job` | Update display name and/or description |
+| `delete_airflow_job` | Delete an Airflow Job (soft or hard delete) |
+| `get_airflow_job_definition` | Retrieve the job's DAG/config definition (base64-decoded) |
+| `update_airflow_job_definition` | Upload a new definition as JSON (auto base64-encoded) |
+
+### Fabric REST API Mapping
+
+All operations target the Fabric REST API under:
+
+```
+https://api.fabric.microsoft.com/v1/workspaces/{workspaceId}/apacheAirflowJobs
+```
+
+| Operation | Method | URL |
+|-----------|--------|-----|
+| List | GET | `.../apacheAirflowJobs` |
+| Create | POST | `.../apacheAirflowJobs` |
+| Get | GET | `.../apacheAirflowJobs/{airflowJobId}` |
+| Update | PATCH | `.../apacheAirflowJobs/{airflowJobId}` |
+| Delete | DELETE | `.../apacheAirflowJobs/{airflowJobId}?hardDelete=true` |
+| Get Definition | POST | `.../apacheAirflowJobs/{airflowJobId}/getDefinition` |
+| Update Definition | POST | `.../apacheAirflowJobs/{airflowJobId}/updateDefinition` |
+
+---
+
+## Files Added / Modified
+
+### New Files
+
+```
+DataFactory.MCP.Core/
+  Models/AirflowJob/
+    AirflowJob.cs                          — Main DTO
+    CreateAirflowJobRequest.cs             — Create request model
+    UpdateAirflowJobRequest.cs             — Update request model
+    ListAirflowJobsResponse.cs             — Paginated list response
+    Definition/
+      AirflowJobDefinition.cs              — Definition container
+      AirflowJobDefinitionPart.cs          — Individual definition part (base64 payload)
+      GetAirflowJobDefinitionResponse.cs   — GET definition response wrapper
+      UpdateAirflowJobDefinitionRequest.cs — PUT definition request wrapper
+  Abstractions/Interfaces/
+    IFabricAirflowJobService.cs            — Service interface
+  Services/
+    FabricAirflowJobService.cs             — Fabric REST API implementation
+  Extensions/
+    AirflowJobExtensions.cs                — ToFormattedInfo() helper
+  Tools/AirflowJob/
+    AirflowJobTool.cs                      — MCP tool entry points
+
+DataFactory.MCP.Tests/
+  Integration/
+    AirflowJobToolIntegrationTests.cs      — 37 integration tests
+```
+
+### Modified Files
+
+```
+DataFactory.MCP.Core/Extensions/ServiceCollectionExtensions.cs
+  — Registered IFabricAirflowJobService + AirflowJobTool
+
+DataFactory.MCP.Tests/Infrastructure/McpTestFixture.cs
+  — Registered AirflowJobTool and FabricAirflowJobService for test DI
+```
+
+---
+
+## Running the Tests
+
+### Prerequisites
+
+- .NET 10 SDK
+- Run from the repo root: `c:\Users\makromer\projects\DataFactoryMCP`
+
+### Run All Airflow Tests (no credentials needed)
+
+```bash
+dotnet test DataFactory.MCP.Tests\DataFactory.MCP.Tests.csproj --filter "AirflowJob"
+```
+
+Expected: **31 pass, 6 skipped** (the 6 skipped are authenticated-only tests).
+
+### Run the Full Test Suite
+
+```bash
+dotnet test
+```
+
+Expected: **136+ pass, ~35 skipped, 0 failed**.
+
+---
+
+## Authenticated (Live API) Tests
+
+Six tests only run when valid Azure AD credentials are available. They are marked with `[SkippableFact]` and auto-skip when unauthenticated.
+
+| Test | What It Verifies |
+|------|-----------------|
+| `ListAirflowJobsAsync_WithAuthentication` | Can list jobs in the test workspace |
+| `ListAirflowJobsAsync_WithInvalidWorkspaceId` | API returns proper GUID validation error |
+| `GetAirflowJobAsync_NonExistentJob` | API returns 404-style error for unknown job |
+| `CreateAirflowJobAsync_ShouldCreateSuccessfully` | Creates a job and cleans it up |
+| `GetAirflowJobDefinitionAsync_NonExistentJob` | API error returned for unknown job |
+| `AirflowJob_FullLifecycle_CreateGetUpdateDeleteAsync` | Full Create → Get → Update → List → GetDefinition → Delete cycle |
+
+### Running Authenticated Tests
+
+Authenticate first using the MCP tool (requires Fabric access — work/org account only):
+
+```
+mcp_datafactorymc_authenticate_interactive
+```
+
+Then run:
+
+```bash
+dotnet test DataFactory.MCP.Tests\DataFactory.MCP.Tests.csproj --filter "AirflowJob"
+```
+
+The `TryAuthenticateAsync()` call inside each test checks for a cached token. If found, the test runs; if not, it skips cleanly.
+
+> **Note:** Fabric Airflow Jobs require a workspace with a `capacityId` (i.e., a Fabric capacity assigned). Free/PPU workspaces may return errors.
+
+---
+
+## Manual Testing via MCP
+
+With the MCP server running in VS Code, you can test all 7 tools interactively through GitHub Copilot:
+
+### 1. Authenticate
+
+```
+mcp_datafactorymc_authenticate_interactive
+```
+
+### 2. Find a workspace with a Fabric capacity
+
+```
+mcp_datafactorymc_list_workspaces
+```
+
+Pick one with a non-null `capacityId`.
+
+### 3. Create an Airflow Job
+
+```
+mcp_datafactorymc_create_airflow_job
+  workspaceId: "<your-workspace-id>"
+  displayName: "My Test Job"
+  description: "Testing the MCP tool"
+```
+
+### 4. List jobs to confirm
+
+```
+mcp_datafactorymc_list_airflow_jobs
+  workspaceId: "<your-workspace-id>"
+```
+
+### 5. Get the job
+
+```
+mcp_datafactorymc_get_airflow_job
+  workspaceId: "<your-workspace-id>"
+  airflowJobId: "<id-from-create-response>"
+```
+
+### 6. Update metadata
+
+```
+mcp_datafactorymc_update_airflow_job
+  workspaceId: "<your-workspace-id>"
+  airflowJobId: "<id>"
+  displayName: "Renamed Job"
+```
+
+### 7. Get the definition
+
+```
+mcp_datafactorymc_get_airflow_job_definition
+  workspaceId: "<your-workspace-id>"
+  airflowJobId: "<id>"
+```
+
+### 8. Update the definition
+
+Provide a JSON object representing the Airflow scheduler config. The tool validates and base64-encodes it automatically:
+
+```
+mcp_datafactorymc_update_airflow_job_definition
+  workspaceId: "<your-workspace-id>"
+  airflowJobId: "<id>"
+  definitionJson: "{\"schedulerConfig\":{}}"
+```
+
+### 9. Delete the job
+
+```
+mcp_datafactorymc_delete_airflow_job
+  workspaceId: "<your-workspace-id>"
+  airflowJobId: "<id>"
+  hardDelete: true
+```
+
+---
+
+## MCP Server Config
+
+The server is configured in `.vscode/mcp.json`. After any code change, restart the MCP server in VS Code:
+
+1. Open the Command Palette (`Ctrl+Shift+P`)
+2. Search for **MCP: Restart Server** or find the server in the MCP panel and click **Restart**
+
+New tools will appear in Copilot after the restart.


### PR DESCRIPTION
## Summary

Adds full MCP tool support for Microsoft Fabric Apache Airflow Jobs, following the existing 3-layer architecture (Tool, Service, Model).

## New MCP Tools (7)

- list_airflow_jobs - List all Airflow Jobs in a workspace (paginated)
- create_airflow_job - Create a new Airflow Job
- get_airflow_job - Get metadata for a specific Airflow Job
- update_airflow_job - Update display name and/or description
- delete_airflow_job - Delete an Airflow Job (soft or hard delete)
- get_airflow_job_definition - Retrieve the job's DAG/config definition (base64-decoded)
- update_airflow_job_definition - Upload a new definition as JSON (auto base64-encoded)

## Fabric REST API

All operations target: workspaces/{workspaceId}/apacheAirflowJobs

## Files Changed

- Models: 8 new DTOs under Models/AirflowJob/ covering all request/response types including definition parts
- Interface: IFabricAirflowJobService with 7 methods
- Service: FabricAirflowJobService calling Fabric REST API
- Extensions: AirflowJobExtensions.ToFormattedInfo()
- Tool: AirflowJobTool with full validation and error handling
- DI: Registered in ServiceCollectionExtensions

## Tests

- 37 integration tests in AirflowJobToolIntegrationTests.cs
- 31 pass without credentials (validation, auth errors, DI registration)
- 6 SkippableFact authenticated tests including a full lifecycle test (Create, Get, Update, List, GetDefinition, Delete)
- Verified manually against live Fabric API

## Docs

Added docs/airflow-job-feature.md with developer testing guide.