### PR TITLE
fix: update fast-uri to 3.1.2 to resolve CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/DataFactory.MCP.Core/Resources/McpApps/package-lock.json
+++ b/DataFactory.MCP.Core/Resources/McpApps/package-lock.json
@@ -2005,9 +2005,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
## Summary

Updates transitive dependency \ast-uri\ from 3.1.0 to 3.1.2 to resolve two high-severity security alerts flagged by Component Governance:

- **CVE-2026-6321** (High)
- **CVE-2026-6322** (High)

## Changes

- \DataFactory.MCP.Core/Resources/McpApps/package-lock.json\: bumped \ast-uri\ 3.1.0 → 3.1.2

## Testing

- \
pm audit\ reports 0 vulnerabilities after update
- No functional changes; lock file update only