### PR TITLE
chore: bump version to 0.22.0-beta

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <!-- Global Version Properties -->
         <MajorVersion>0</MajorVersion>
-        <MinorVersion>21</MinorVersion>
+        <MinorVersion>22</MinorVersion>
         <PatchVersion>0</PatchVersion>
         <PreReleaseLabel>beta</PreReleaseLabel>
 


### PR DESCRIPTION
Bumps version from 0.21.0-beta to 0.22.0-beta to reflect the addition of Apache Airflow Job tools and source-gen JSON fixes.