### PR TITLE
feat(pipeline): add upsert_pipeline_activity and remove_pipeline_activity tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ tmpclaude-*
 **/McpApps/node_modules/
 **/McpApps/dist/
 **/build-output.txt
+
+# Local Fabric tooling state (not source)
+.fabric/
+.workspaces/
+fabric-di.yaml
+probe-endpoints.ps1

--- a/DataFactory.MCP.Core/Configuration/DataFactoryJsonContext.cs
+++ b/DataFactory.MCP.Core/Configuration/DataFactoryJsonContext.cs
@@ -67,6 +67,7 @@ namespace DataFactory.MCP.Configuration;
 [JsonSerializable(typeof(Models.Pipeline.ItemJobInstance), TypeInfoPropertyName = "PipelineItemJobInstance")]
 // Pipeline Schedule types
 [JsonSerializable(typeof(CreateScheduleRequest))]
+[JsonSerializable(typeof(UpdateScheduleRequest))]
 [JsonSerializable(typeof(ItemSchedule))]
 [JsonSerializable(typeof(ListSchedulesResponse))]
 // Pipeline Definition types

--- a/DataFactory.MCP.Core/Tools/Pipeline/PipelineTool.cs
+++ b/DataFactory.MCP.Core/Tools/Pipeline/PipelineTool.cs
@@ -2,6 +2,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using DataFactory.MCP.Abstractions.Interfaces;
 using DataFactory.MCP.Extensions;
 using DataFactory.MCP.Handlers;
@@ -519,6 +520,386 @@ public class PipelineTool
         {
             return ex.ToOperationError("updating pipeline schedule enabled state").ToMcpJson();
         }
+    }
+
+    private static readonly HashSet<string> ValidDependencyConditions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Succeeded", "Failed", "Skipped", "Completed"
+    };
+
+    [McpServerTool, Description(@"Adds or replaces a single activity in an existing pipeline definition. Uses upsert-by-name semantics: if an activity with the same name exists it is replaced; otherwise it is appended. Validates dependency graph integrity before saving.")]
+    public async Task<string> UpsertPipelineActivityAsync(
+        [Description("The workspace ID containing the pipeline (required)")] string workspaceId,
+        [Description("The pipeline ID to update (required)")] string pipelineId,
+        [Description("The activity JSON object with at minimum 'name' and 'type' fields (required)")] string activityJson,
+        [Description("Optional JSON array of dependsOn entries, e.g. [{\"activity\":\"Step1\",\"dependencyConditions\":[\"Succeeded\"]}]. Overrides any dependsOn in activityJson when provided (optional)")] string? dependsOnJson = null)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(pipelineId, nameof(pipelineId));
+            _validationService.ValidateRequiredString(activityJson, nameof(activityJson));
+
+            // Parse and validate activity JSON
+            JsonNode? activityNode;
+            try
+            {
+                activityNode = JsonNode.Parse(activityJson);
+            }
+            catch (JsonException ex)
+            {
+                throw new ArgumentException($"Invalid activityJson format: {ex.Message}");
+            }
+
+            if (activityNode is not JsonObject activityObj)
+                throw new ArgumentException("activityJson must be a JSON object");
+
+            var activityName = activityObj["name"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(activityName))
+                throw new ArgumentException("Activity must have a non-empty 'name' property");
+
+            var activityType = activityObj["type"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(activityType))
+                throw new ArgumentException("Activity must have a non-empty 'type' property");
+
+            // Parse and apply dependsOn override if provided
+            if (!string.IsNullOrEmpty(dependsOnJson))
+            {
+                JsonNode? dependsOnNode;
+                try
+                {
+                    dependsOnNode = JsonNode.Parse(dependsOnJson);
+                }
+                catch (JsonException ex)
+                {
+                    throw new ArgumentException($"Invalid dependsOnJson format: {ex.Message}");
+                }
+
+                if (dependsOnNode is not JsonArray)
+                    throw new ArgumentException("dependsOnJson must be a JSON array");
+
+                activityObj["dependsOn"] = dependsOnNode.DeepClone();
+            }
+
+            // Pre-service validation: self-dependency and condition checks
+            ValidateActivityDependencies(activityObj, activityName);
+
+            // Type-property warnings (non-blocking)
+            var warnings = ValidateActivityTypeProperties(activityObj);
+
+            // Get current pipeline definition
+            var currentDefinition = await _pipelineService.GetPipelineDefinitionAsync(workspaceId, pipelineId);
+
+            var contentPart = currentDefinition.Parts.FirstOrDefault(p => p.Path == "pipeline-content.json")
+                ?? throw new ArgumentException("Pipeline definition does not contain a 'pipeline-content.json' part");
+
+            var contentJson = Encoding.UTF8.GetString(Convert.FromBase64String(contentPart.Payload));
+            var contentNode = JsonNode.Parse(contentJson)
+                ?? throw new ArgumentException("Failed to parse pipeline content JSON");
+
+            var properties = contentNode["properties"]?.AsObject()
+                ?? throw new ArgumentException("Pipeline content missing 'properties' object");
+
+            var activities = properties["activities"]?.AsArray();
+            if (activities == null)
+            {
+                activities = new JsonArray();
+                properties["activities"] = activities;
+            }
+
+            // Upsert-by-name
+            bool replaced = false;
+            for (int i = 0; i < activities.Count; i++)
+            {
+                var existingName = activities[i]?["name"]?.GetValue<string>();
+                if (existingName == activityName)
+                {
+                    activities[i] = activityObj.DeepClone();
+                    replaced = true;
+                    break;
+                }
+            }
+
+            if (!replaced)
+            {
+                activities.Add(activityObj.DeepClone());
+            }
+
+            // Validate full graph integrity
+            ValidateActivityGraph(activities);
+
+            // Re-serialize and update
+            var updatedContentJson = contentNode.ToJsonString();
+            var base64Payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(updatedContentJson));
+
+            var definition = new PipelineDefinition
+            {
+                Parts = new List<PipelineDefinitionPart>
+                {
+                    new PipelineDefinitionPart
+                    {
+                        Path = "pipeline-content.json",
+                        Payload = base64Payload,
+                        PayloadType = "InlineBase64"
+                    }
+                }
+            };
+
+            await _pipelineService.UpdatePipelineDefinitionAsync(workspaceId, pipelineId, definition);
+
+            var result = new
+            {
+                Success = true,
+                Message = replaced
+                    ? $"Activity '{activityName}' replaced successfully"
+                    : $"Activity '{activityName}' added successfully",
+                ActivityName = activityName,
+                ActivityType = activityType,
+                Operation = replaced ? "Replaced" : "Added",
+                TotalActivityCount = activities.Count,
+                PipelineId = pipelineId,
+                WorkspaceId = workspaceId,
+                Warnings = warnings.Count > 0 ? warnings : null
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("upserting pipeline activity").ToMcpJson();
+        }
+    }
+
+    [McpServerTool, Description(@"Removes a single activity from an existing pipeline definition by name. Refuses removal if other activities depend on it via dependsOn references.")]
+    public async Task<string> RemovePipelineActivityAsync(
+        [Description("The workspace ID containing the pipeline (required)")] string workspaceId,
+        [Description("The pipeline ID to update (required)")] string pipelineId,
+        [Description("The name of the activity to remove (required)")] string activityName)
+    {
+        try
+        {
+            _validationService.ValidateRequiredString(workspaceId, nameof(workspaceId));
+            _validationService.ValidateRequiredString(pipelineId, nameof(pipelineId));
+            _validationService.ValidateRequiredString(activityName, nameof(activityName));
+
+            var currentDefinition = await _pipelineService.GetPipelineDefinitionAsync(workspaceId, pipelineId);
+
+            var contentPart = currentDefinition.Parts.FirstOrDefault(p => p.Path == "pipeline-content.json")
+                ?? throw new ArgumentException("Pipeline definition does not contain a 'pipeline-content.json' part");
+
+            var contentJson = Encoding.UTF8.GetString(Convert.FromBase64String(contentPart.Payload));
+            var contentNode = JsonNode.Parse(contentJson)
+                ?? throw new ArgumentException("Failed to parse pipeline content JSON");
+
+            var properties = contentNode["properties"]?.AsObject()
+                ?? throw new ArgumentException("Pipeline content missing 'properties' object");
+
+            var activities = properties["activities"]?.AsArray()
+                ?? throw new ArgumentException("Pipeline has no activities array");
+
+            // Find the activity to remove
+            int removeIndex = -1;
+            for (int i = 0; i < activities.Count; i++)
+            {
+                if (activities[i]?["name"]?.GetValue<string>() == activityName)
+                {
+                    removeIndex = i;
+                    break;
+                }
+            }
+
+            if (removeIndex < 0)
+                throw new ArgumentException($"Activity '{activityName}' not found in pipeline");
+
+            // Check for dependsOn references from other activities
+            var dependentActivities = new List<string>();
+            foreach (var act in activities)
+            {
+                var name = act?["name"]?.GetValue<string>();
+                if (name == activityName) continue;
+
+                var dependsOn = act?["dependsOn"]?.AsArray();
+                if (dependsOn == null) continue;
+
+                foreach (var dep in dependsOn)
+                {
+                    if (dep?["activity"]?.GetValue<string>() == activityName)
+                    {
+                        dependentActivities.Add(name ?? "(unnamed)");
+                        break;
+                    }
+                }
+            }
+
+            if (dependentActivities.Count > 0)
+                throw new ArgumentException($"Cannot remove activity '{activityName}' because it is referenced by: {string.Join(", ", dependentActivities)}");
+
+            activities.RemoveAt(removeIndex);
+
+            // Re-serialize and update
+            var updatedContentJson = contentNode.ToJsonString();
+            var base64Payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(updatedContentJson));
+
+            var definition = new PipelineDefinition
+            {
+                Parts = new List<PipelineDefinitionPart>
+                {
+                    new PipelineDefinitionPart
+                    {
+                        Path = "pipeline-content.json",
+                        Payload = base64Payload,
+                        PayloadType = "InlineBase64"
+                    }
+                }
+            };
+
+            await _pipelineService.UpdatePipelineDefinitionAsync(workspaceId, pipelineId, definition);
+
+            var result = new
+            {
+                Success = true,
+                Message = $"Activity '{activityName}' removed successfully",
+                RemovedActivity = activityName,
+                RemainingActivityCount = activities.Count,
+                PipelineId = pipelineId,
+                WorkspaceId = workspaceId
+            };
+
+            return result.ToMcpJson();
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.ToValidationError().ToMcpJson();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ex.ToAuthenticationError().ToMcpJson();
+        }
+        catch (HttpRequestException ex)
+        {
+            return ex.ToHttpError().ToMcpJson();
+        }
+        catch (Exception ex)
+        {
+            return ex.ToOperationError("removing pipeline activity").ToMcpJson();
+        }
+    }
+
+    private static void ValidateActivityDependencies(JsonObject activity, string activityName)
+    {
+        var dependsOn = activity["dependsOn"]?.AsArray();
+        if (dependsOn == null || dependsOn.Count == 0) return;
+
+        foreach (var dep in dependsOn)
+        {
+            var depObj = dep?.AsObject();
+            if (depObj == null) continue;
+
+            var depActivity = depObj["activity"]?.GetValue<string>();
+            if (depActivity == activityName)
+                throw new ArgumentException($"Activity '{activityName}' cannot depend on itself");
+
+            var conditions = depObj["dependencyConditions"]?.AsArray();
+            if (conditions != null)
+            {
+                foreach (var cond in conditions)
+                {
+                    var condValue = cond?.GetValue<string>();
+                    if (condValue != null && !ValidDependencyConditions.Contains(condValue))
+                        throw new ArgumentException($"Invalid dependency condition '{condValue}'. Valid values: Succeeded, Failed, Skipped, Completed");
+                }
+            }
+        }
+    }
+
+    private static void ValidateActivityGraph(JsonArray activities)
+    {
+        var activityNames = new HashSet<string>();
+        foreach (var act in activities)
+        {
+            var name = act?["name"]?.GetValue<string>();
+            if (name != null) activityNames.Add(name);
+        }
+
+        foreach (var act in activities)
+        {
+            var actObj = act?.AsObject();
+            if (actObj == null) continue;
+            var name = actObj["name"]?.GetValue<string>() ?? "";
+            var dependsOn = actObj["dependsOn"]?.AsArray();
+            if (dependsOn == null) continue;
+
+            foreach (var dep in dependsOn)
+            {
+                var depObj = dep?.AsObject();
+                if (depObj == null) continue;
+                var depActivity = depObj["activity"]?.GetValue<string>();
+
+                if (depActivity == name)
+                    throw new ArgumentException($"Activity '{name}' cannot depend on itself");
+
+                if (depActivity != null && !activityNames.Contains(depActivity))
+                    throw new ArgumentException($"Activity '{name}' depends on '{depActivity}' which does not exist in the pipeline");
+
+                var conditions = depObj["dependencyConditions"]?.AsArray();
+                if (conditions != null)
+                {
+                    foreach (var cond in conditions)
+                    {
+                        var condValue = cond?.GetValue<string>();
+                        if (condValue != null && !ValidDependencyConditions.Contains(condValue))
+                            throw new ArgumentException($"Invalid dependency condition '{condValue}' in activity '{name}'. Valid values: Succeeded, Failed, Skipped, Completed");
+                    }
+                }
+            }
+        }
+    }
+
+    private static List<string> ValidateActivityTypeProperties(JsonObject activity)
+    {
+        var warnings = new List<string>();
+        var type = activity["type"]?.GetValue<string>();
+        var typeProperties = activity["typeProperties"]?.AsObject();
+
+        if (typeProperties == null)
+        {
+            if (type is "DataflowActivity" or "Copy" or "TridentNotebook" or "Web")
+                warnings.Add($"Activity type '{type}' typically requires typeProperties");
+            return warnings;
+        }
+
+        switch (type)
+        {
+            case "DataflowActivity":
+                if (typeProperties["dataflowId"] == null) warnings.Add("DataflowActivity: missing typeProperties.dataflowId");
+                if (typeProperties["workspaceId"] == null) warnings.Add("DataflowActivity: missing typeProperties.workspaceId");
+                break;
+            case "Copy":
+                if (typeProperties["source"] == null) warnings.Add("Copy: missing typeProperties.source");
+                if (typeProperties["sink"] == null) warnings.Add("Copy: missing typeProperties.sink");
+                break;
+            case "TridentNotebook":
+                if (typeProperties["notebookId"] == null) warnings.Add("TridentNotebook: missing typeProperties.notebookId");
+                break;
+            case "Web":
+                if (typeProperties["url"] == null) warnings.Add("Web: missing typeProperties.url");
+                if (typeProperties["method"] == null) warnings.Add("Web: missing typeProperties.method");
+                break;
+        }
+
+        return warnings;
     }
 
     /// <summary>

--- a/DataFactory.MCP.Tests/Integration/PipelineToolIntegrationTests.cs
+++ b/DataFactory.MCP.Tests/Integration/PipelineToolIntegrationTests.cs
@@ -546,6 +546,179 @@ public class PipelineToolIntegrationTests : FabricToolIntegrationTestBase
 
     #endregion
 
+    #region UpsertPipelineActivityAsync
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Arrange
+        var activityJson = "{\"name\":\"TestActivity\",\"type\":\"Web\"}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync("", InvalidPipelineId, activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithEmptyPipelineId_ShouldReturnValidationError()
+    {
+        // Arrange
+        var activityJson = "{\"name\":\"TestActivity\",\"type\":\"Web\"}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, "", activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("pipelineId"));
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithEmptyActivityJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("activityJson"));
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithInvalidActivityJson_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, "not-valid-json{");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid activityJson format");
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithMissingActivityName_ShouldReturnValidationError()
+    {
+        // Arrange
+        var activityJson = "{\"type\":\"Web\"}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Activity must have a non-empty 'name' property");
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithMissingActivityType_ShouldReturnValidationError()
+    {
+        // Arrange
+        var activityJson = "{\"name\":\"TestActivity\"}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Activity must have a non-empty 'type' property");
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithSelfDependency_ShouldReturnValidationError()
+    {
+        // Arrange - activity depends on itself
+        var activityJson = "{\"name\":\"MyActivity\",\"type\":\"Web\",\"dependsOn\":[{\"activity\":\"MyActivity\",\"dependencyConditions\":[\"Succeeded\"]}]}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Activity 'MyActivity' cannot depend on itself");
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithInvalidDependencyCondition_ShouldReturnValidationError()
+    {
+        // Arrange - activity has an invalid dependency condition
+        var activityJson = "{\"name\":\"MyActivity\",\"type\":\"Web\",\"dependsOn\":[{\"activity\":\"OtherActivity\",\"dependencyConditions\":[\"InvalidCondition\"]}]}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid dependency condition 'InvalidCondition'");
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Arrange - valid activity that passes all validation
+        var activityJson = "{\"name\":\"TestActivity\",\"type\":\"Web\",\"dependsOn\":[]}";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson);
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    [Fact]
+    public async Task UpsertPipelineActivityAsync_WithInvalidDependsOnJson_ShouldReturnValidationError()
+    {
+        // Arrange
+        var activityJson = "{\"name\":\"TestActivity\",\"type\":\"Web\"}";
+        var dependsOnJson = "not-valid-json{";
+
+        // Act
+        var result = await _pipelineTool.UpsertPipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, activityJson, dependsOnJson);
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, "Invalid dependsOnJson format");
+    }
+
+    #endregion
+
+    #region RemovePipelineActivityAsync
+
+    [Fact]
+    public async Task RemovePipelineActivityAsync_WithEmptyWorkspaceId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _pipelineTool.RemovePipelineActivityAsync("", InvalidPipelineId, "TestActivity");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("workspaceId"));
+    }
+
+    [Fact]
+    public async Task RemovePipelineActivityAsync_WithEmptyPipelineId_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _pipelineTool.RemovePipelineActivityAsync(TestWorkspaceId, "", "TestActivity");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("pipelineId"));
+    }
+
+    [Fact]
+    public async Task RemovePipelineActivityAsync_WithEmptyActivityName_ShouldReturnValidationError()
+    {
+        // Act
+        var result = await _pipelineTool.RemovePipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, "");
+
+        // Assert
+        McpResponseAssertHelper.AssertValidationError(result, Messages.InvalidParameterEmpty("activityName"));
+    }
+
+    [Fact]
+    public async Task RemovePipelineActivityAsync_WithoutAuthentication_ShouldReturnAuthenticationError()
+    {
+        // Act
+        var result = await _pipelineTool.RemovePipelineActivityAsync(TestWorkspaceId, InvalidPipelineId, "TestActivity");
+
+        // Assert
+        AssertAuthenticationError(result);
+    }
+
+    #endregion
+
 
     #region Authenticated Scenarios
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Model Context Protocol (MCP) server for Microsoft Fabric resource discovery an
 - **Dataflow Refresh**: `refresh_dataflow_background`, `refresh_dataflow_status`
 - **Dataflow Query Execution**: `execute_query` *(Preview)*
 - **Capacity Management**: `list_capacities`
-- **Pipeline Management**: `list_pipelines`, `create_pipeline`, `get_pipeline`, `update_pipeline`, `get_pipeline_definition`, `update_pipeline_definition`, `run_pipeline`, `get_pipeline_run_status`, `create_pipeline_schedule`, `list_pipeline_schedules`, `set_pipeline_schedule_enabled` *(Preview)*
+- **Pipeline Management**: `list_pipelines`, `create_pipeline`, `get_pipeline`, `update_pipeline`, `get_pipeline_definition`, `update_pipeline_definition`, `upsert_pipeline_activity`, `remove_pipeline_activity`, `run_pipeline`, `get_pipeline_run_status`, `create_pipeline_schedule`, `list_pipeline_schedules`, `set_pipeline_schedule_enabled` *(Preview)*
 - **Copy Job Management**: `list_copy_jobs`, `create_copy_job`, `get_copy_job`, `update_copy_job`, `get_copy_job_definition`, `update_copy_job_definition`, `run_copy_job`, `get_copy_job_run_status`, `create_copy_job_schedule`, `list_copy_job_schedules` *(Preview)*
 - **Apache Airflow Job Management**: `list_airflow_jobs`, `create_airflow_job`, `get_airflow_job`, `update_airflow_job`, `delete_airflow_job`, `get_airflow_job_definition`, `update_airflow_job_definition` *(Preview)*
 

--- a/claude-skills/SKILL.md
+++ b/claude-skills/SKILL.md
@@ -75,3 +75,6 @@ Operational knowledge for working with Microsoft Fabric Data Factory.
 | `templates/m-sharepoint-excel-source.m` | Need the M snippet for SharePoint Excel via Web.Contents |
 | `templates/pipeline-single-dataflow.json` | Need pipeline JSON for a single Dataflow activity |
 | `templates/pipeline-chained-dataflows.json` | Need pipeline JSON for chained Dataflow activities |
+| `templates/activity-copy.json` | Need a Copy activity object for `upsert_pipeline_activity` |
+| `templates/activity-notebook.json` | Need a TridentNotebook activity object for `upsert_pipeline_activity` |
+| `templates/activity-web.json` | Need a Web activity object for `upsert_pipeline_activity` |

--- a/claude-skills/datafactory-pipelines.md
+++ b/claude-skills/datafactory-pipelines.md
@@ -55,6 +55,59 @@ Use `dependsOn` to sequence activities. Use `templates/pipeline-chained-dataflow
 
 Dependency conditions: `Succeeded`, `Failed`, `Skipped`, `Completed` (any outcome).
 
+## Add or Modify a Single Activity
+
+Use `upsert_pipeline_activity` to add or replace a single activity without
+hand-editing the full pipeline definition.
+
+### Upsert-by-name semantics
+
+The tool matches by `name`. If an activity with the same name already exists it
+is **replaced**; otherwise the new activity is **appended**.
+
+```python
+upsert_pipeline_activity(
+  workspaceId="...",
+  pipelineId="...",
+  activityJson='{"name":"LoadNotebook","type":"TridentNotebook","dependsOn":[],"typeProperties":{"notebookId":"NOTEBOOK_ID"}}'
+)
+```
+
+### Wiring dependencies
+
+Pass `dependsOnJson` to set or override the activity's `dependsOn` array. This
+is useful when the activity template has an empty `dependsOn` but you want to
+chain it after another activity:
+
+```python
+upsert_pipeline_activity(
+  workspaceId="...",
+  pipelineId="...",
+  activityJson='{"name":"Transform","type":"TridentNotebook","dependsOn":[],"typeProperties":{"notebookId":"NB_ID"}}',
+  dependsOnJson='[{"activity":"Extract","dependencyConditions":["Succeeded"]}]'
+)
+```
+
+### Removing an activity
+
+Use `remove_pipeline_activity` to remove an activity by name. The tool refuses
+removal if any other activity's `dependsOn` references it — update or remove
+dependent activities first.
+
+```python
+remove_pipeline_activity(
+  workspaceId="...",
+  pipelineId="...",
+  activityName="OldStep"
+)
+```
+
+### Activity body templates
+
+Use `templates/activity-copy.json`, `templates/activity-notebook.json`, or
+`templates/activity-web.json` for the activity body shape. Replace placeholder
+values and pass as `activityJson`.
+
 ## Scheduling
 
 Schedules **can** be created via the MCP using `create_pipeline_schedule`

--- a/claude-skills/templates/activity-copy.json
+++ b/claude-skills/templates/activity-copy.json
@@ -1,0 +1,21 @@
+// Replace: ACTIVITY_NAME, SOURCE_TYPE, SINK_TYPE
+// Pass this JSON as the activityJson parameter to upsert_pipeline_activity
+// source and sink objects vary by connector — see Fabric documentation for your connector type
+{
+  "name": "ACTIVITY_NAME",
+  "type": "Copy",
+  "dependsOn": [],
+  "policy": {
+    "timeout": "0.01:00:00",
+    "retry": 1,
+    "retryIntervalInSeconds": 60
+  },
+  "typeProperties": {
+    "source": {
+      "type": "SOURCE_TYPE"
+    },
+    "sink": {
+      "type": "SINK_TYPE"
+    }
+  }
+}

--- a/claude-skills/templates/activity-notebook.json
+++ b/claude-skills/templates/activity-notebook.json
@@ -1,0 +1,16 @@
+// Replace: ACTIVITY_NAME, NOTEBOOK_ID (from Fabric workspace)
+// Pass this JSON as the activityJson parameter to upsert_pipeline_activity
+// Optional: add "parameters" under typeProperties to pass values into the notebook
+{
+  "name": "ACTIVITY_NAME",
+  "type": "TridentNotebook",
+  "dependsOn": [],
+  "policy": {
+    "timeout": "0.12:00:00",
+    "retry": 0,
+    "retryIntervalInSeconds": 30
+  },
+  "typeProperties": {
+    "notebookId": "NOTEBOOK_ID"
+  }
+}

--- a/claude-skills/templates/activity-web.json
+++ b/claude-skills/templates/activity-web.json
@@ -1,0 +1,17 @@
+// Replace: ACTIVITY_NAME, URL, METHOD (GET, POST, PUT, DELETE, PATCH)
+// Pass this JSON as the activityJson parameter to upsert_pipeline_activity
+// Optional: add "headers", "body" under typeProperties for POST/PUT requests
+{
+  "name": "ACTIVITY_NAME",
+  "type": "Web",
+  "dependsOn": [],
+  "policy": {
+    "timeout": "0.00:10:00",
+    "retry": 1,
+    "retryIntervalInSeconds": 30
+  },
+  "typeProperties": {
+    "url": "URL",
+    "method": "METHOD"
+  }
+}

--- a/claude-skills/templates/activity-web.json
+++ b/claude-skills/templates/activity-web.json
@@ -3,7 +3,7 @@
 // Optional: add "headers", "body" under typeProperties for POST/PUT requests
 {
   "name": "ACTIVITY_NAME",
-  "type": "Web",
+  "type": "WebActivity",
   "dependsOn": [],
   "policy": {
     "timeout": "0.00:10:00",

--- a/docs/pipeline-management.md
+++ b/docs/pipeline-management.md
@@ -11,6 +11,8 @@ The pipeline management tools allow you to:
 - **Update** pipeline metadata (display name and description)
 - **Get** pipeline definitions with decoded base64 content
 - **Update** pipeline definitions with JSON content
+- **Upsert** a single activity by name (add or replace)
+- **Remove** a single activity by name (with dependency safety)
 - **Run** pipelines on demand (with optional execution data)
 - **Check** pipeline run status by job instance ID
 - **Create** pipeline schedules (Cron, Daily, Weekly, Monthly)
@@ -256,6 +258,86 @@ update_pipeline_definition(
   "pipelineId": "87654321-4321-4321-4321-210987654321",
   "workspaceId": "12345678-1234-1234-1234-123456789012",
   "message": "Pipeline definition updated successfully"
+}
+```
+
+### upsert_pipeline_activity
+
+Adds or replaces a single activity in an existing pipeline definition. Uses upsert-by-name semantics: if an activity with the same name exists it is replaced; otherwise it is appended. Validates dependency graph integrity before saving.
+
+#### Usage
+```
+upsert_pipeline_activity(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  pipelineId: "87654321-4321-4321-4321-210987654321",
+  activityJson: "{\"name\":\"LoadNotebook\",\"type\":\"TridentNotebook\",\"dependsOn\":[],\"typeProperties\":{\"notebookId\":\"NOTEBOOK_ID\"}}"
+)
+```
+
+#### With Dependency Wiring
+```
+upsert_pipeline_activity(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  pipelineId: "87654321-4321-4321-4321-210987654321",
+  activityJson: "{\"name\":\"Transform\",\"type\":\"TridentNotebook\",\"dependsOn\":[],\"typeProperties\":{\"notebookId\":\"NB_ID\"}}",
+  dependsOnJson: "[{\"activity\":\"Extract\",\"dependencyConditions\":[\"Succeeded\"]}]"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the pipeline |
+| `pipelineId` | Yes | The pipeline ID to update |
+| `activityJson` | Yes | The activity JSON object with at minimum `name` and `type` fields |
+| `dependsOnJson` | No | JSON array of dependsOn entries. Overrides any dependsOn in activityJson when provided |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Activity 'LoadNotebook' added successfully",
+  "activityName": "LoadNotebook",
+  "activityType": "TridentNotebook",
+  "operation": "Added",
+  "totalActivityCount": 3,
+  "pipelineId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012",
+  "warnings": null
+}
+```
+
+### remove_pipeline_activity
+
+Removes a single activity from an existing pipeline definition by name. Refuses removal if other activities depend on it via dependsOn references.
+
+#### Usage
+```
+remove_pipeline_activity(
+  workspaceId: "12345678-1234-1234-1234-123456789012",
+  pipelineId: "87654321-4321-4321-4321-210987654321",
+  activityName: "OldStep"
+)
+```
+
+#### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `workspaceId` | Yes | The workspace ID containing the pipeline |
+| `pipelineId` | Yes | The pipeline ID to update |
+| `activityName` | Yes | The name of the activity to remove |
+
+#### Response Format
+```json
+{
+  "success": true,
+  "message": "Activity 'OldStep' removed successfully",
+  "removedActivity": "OldStep",
+  "remainingActivityCount": 2,
+  "pipelineId": "87654321-4321-4321-4321-210987654321",
+  "workspaceId": "12345678-1234-1234-1234-123456789012"
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds two server-side MCP tools to add, replace, or remove a **single top-level pipeline activity** without hand-reconstructing the full pipeline definition JSON. Addresses microsoft/mcp#3253.

Previously, activity edits required `get_pipeline_definition` -> hand-edit the whole JSON -> `update_pipeline_definition` (full replace). These tools perform the read-modify-write server-side, preserving unrelated activities and sibling content properties while applying the local guards described below.

## New tools and scope

- **`upsert_pipeline_activity(workspaceId, pipelineId, activityJson, dependsOnJson?)`** targets only the root `properties.activities` array by exact, case-sensitive activity name. It replaces the **entire existing activity object** (no merge), or appends when no top-level name matches. Optional `dependsOnJson` overrides the submitted activity's inline dependencies.
- **`remove_pipeline_activity(workspaceId, pipelineId, activityName)`** removes an exact, case-sensitive top-level name and refuses removal when another top-level activity references it via `dependsOn`.
- Names inside ForEach, Switch, or other nested containers are not individually targeted. A nested-only upsert name appends a new top-level activity; nested-only removal returns not found. If a top-level entry and a nested child share a name, only the top-level entry is targeted.
- To edit or remove a nested child, submit the **complete enclosing top-level container**, including all children and properties to retain. There is no nested-targeting API. Unrelated activities, existing nested container content, and sibling content properties are preserved; omitted fields or children of the replaced activity are not merged back.

## Validation contract and review feedback addressed

- Local guards check required inputs and top-level dependency references/conditions: missing targets, self-dependency, and supported conditions (`Succeeded`, `Failed`, `Skipped`, `Completed`). Removal checks top-level dependent references.
- These are **not comprehensive schema or cycle checks**. Nested dependencies and the full dependency graph are not validated.
- Removed the partial advisory `ValidateActivityTypeProperties` helper and the `warnings` success field. Activity-type-specific payloads, including the shape and contents of `typeProperties`, are forwarded without local schema validation.
- A successful tool response does **not** guarantee runtime validity or comprehensive synchronous Fabric validation. Templates provide authoring guidance, not local schema enforcement.

## Also included

- Skill guidance (`claude-skills/SKILL.md`, `datafactory-pipelines.md`), activity-body templates (`activity-copy/notebook/web.json`), and documentation (`README.md`, `docs/pipeline-management.md`) describing scope, whole-object replacement, and validation limits. Submit strict JSON without template guidance comments.
- Notebook examples/template include `typeProperties.notebookId` and `typeProperties.workspaceId`. The notebook workspace property is separate from the outer MCP `workspaceId`, which identifies the pipeline workspace; it is not automatically populated, even when both workspaces are the same.
- The WebActivity template uses `typeProperties.relativeUrl`, `typeProperties.method`, and activity-level `externalReferences.connection` with an appropriate existing Fabric connection.
- Trim-safe JSON source-generation registration from the original PR remains included.
- 67 new offline regression cases plus the 14 original activity tests.

## Verification

Previously completed against this source state; not rerun for publication:

- Build: `dotnet build '.\DataFactory.MCP.Tests\DataFactory.MCP.Tests.csproj' -c Debug --no-restore` exited **0**, with **0 warnings / 0 errors**. `NETSDK1057` was preview SDK informational output.
- Targeted tests: **81 passed / 0 failed / 0 skipped**, comprising **67 new offline regressions + 14 original activity tests**:

```powershell
dotnet test '.\DataFactory.MCP.Tests\DataFactory.MCP.Tests.csproj' -c Debug --no-build --no-restore --filter '(FullyQualifiedName~DataFactory.MCP.Tests.Integration.PipelineToolIntegrationTests.UpsertPipelineActivityAsync|FullyQualifiedName~DataFactory.MCP.Tests.Integration.PipelineToolIntegrationTests.RemovePipelineActivityAsync|FullyQualifiedName~DataFactory.MCP.Tests.Unit.PipelineActivityToolTests)'
```

- Coverage is fake-backed success/response-shape/content-preservation plus signed-out and early-validation behavior, **not live Fabric testing**. Fake service completion does not establish Fabric schema acceptance or pipeline runtime validity.
- Reviewer reported no substantive/blocking findings across the full diff, including the new test file. `git diff --check` and the staged diff check were clean.

## Known limitation: concurrency

The underlying `update_pipeline_definition` path has **no ETag/optimistic concurrency**. The server-side read-modify-write therefore retains a **last-writer-wins** race window. An If-Match/optimistic-concurrency follow-up remains out of scope for this PR.
